### PR TITLE
initial cname ref tests

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -70,6 +70,30 @@
                 "expectAction": "block"
             },
             {
+                "name": "random blocks cname tracker",
+                "siteURL": "https://randomsite123.com/",
+                "requestURL": "https://bad.cnames.test/something",
+                "requestType": "script",
+                "expectAction": "block"
+            },
+            {
+                "name": "random allows sub.cname tracker",
+                "siteURL": "https://randomsite123.com/",
+                "requestURL": "https://also.bad.cnames.test/something",
+                "requestType": "script",
+                "expectAction": null,
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
+            },
+            {
+                "name": "random allows notbad cname tracker",
+                "siteURL": "https://randomsite123.com/",
+                "requestURL": "https://notbad.cnames.test/something",
+                "requestType": "script",
+                "expectAction": null
+            },
+            {
                 "name": "sub.ignore loads tracker",
                 "siteURL": "https://sub.ignore.test/",
                 "requestURL": "https://bad.third-party.site/",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -100,7 +100,9 @@
             "displayName": "ignore Site for Tracker Blocking"
         }
     },
-    "cnames": {},
+    "cnames": {
+        "bad.cnames.test": "cname.tracker.test"
+    },
     "domains": {
         "bad.third-party.site": "Test Site for Tracker Blocking",
         "broken.third-party.site": "Test Site for Tracker Blocking",


### PR DESCRIPTION
Initial swag at CNAME reference tests.  Interesting to note that the second test ("random allows sub.cname tracker") passes in the extension but returns "block" in iOS and fails.  

I've added it as an exemption for now (PR pending in iOS to support it), but I think its an interesting finding and worth discussing next week.  