### PR TITLE
Privacy configuration tests

### DIFF
--- a/privacy-configuration/README.MD
+++ b/privacy-configuration/README.MD
@@ -1,0 +1,42 @@
+# Privacy Configuration Tests
+
+Privacy Feature: https://app.asana.com/0/1198207348643509/1199981227466169/f
+
+## Goals
+
+This set of tests verifies implementation of privacy configuration. In particular it focuses on verifying that:
+
+- features are correctly enabled / disabled according to the global setting ("state"),
+- exceptions are taken into account ("exceptions", "unprotectedTemporary") and url matching is according to the spec ("domain"),
+- features are correctly injected, or not, into iframes ("aboutBlank", "aboutBlankSites"),
+- features are correctly disabled for specific scripts ("script"),
+- features missing from the config are disabled and don't cause a crash.
+
+## Structure
+
+There are multiple sets of tests in `tests.json` and multiple config files. Each set defines what configuration file (`configX_reference.json`) is expected to be loaded via "referenceConfig" field.
+
+Test suite specific fields:
+
+- featureName - string - name of the privacy feature as defined in the config
+- siteURL - string - currently loaded website's URL (as seen in the URL bar)
+- frameURL - string - URL of an iframe in which the feature is operating (optional - if not set assume main frame context)
+- scriptURL - string - URL of script that is trying to use a protected feature (optional - if not set assume no script URL)
+- expectFeatureEnabled - bool - if feature is expected to be disabled or not
+
+## Pseudo-code implementation
+
+```
+for $testSet in test.json
+  loadRemoteConfig($testSet.referenceConfig)
+
+  for $test in $testSet
+    $enabled = isEnabled(
+        feature=$test.featureName,
+        url=$test.siteURL,
+        frame=$test.frameURL,
+        script=$test.scriptURL
+    )
+
+    expect($enabled === $test.expectFeatureEnabled)
+```

--- a/privacy-configuration/config1_reference.json
+++ b/privacy-configuration/config1_reference.json
@@ -1,0 +1,167 @@
+{
+    "readme": "This configuration has all features disabled.",
+    "features": {
+        "https": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "contentBlocking": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                },
+                {
+                    "domain": "dont.block.co.uk",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "trackerAllowlist": {
+            "state": "disabled",
+            "settings": {
+                "allowlistedTrackers": {}
+            },
+            "exceptions": []
+        },
+        "trackingCookies3p": {
+            "state": "disabled",
+            "settings": {
+                "excludedCookieDomains": [
+                    {
+                        "domain": "hangouts.google.com",
+                        "reason": "Site breakage"
+                    }
+                ]
+            },
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "trackingCookies1p": {
+            "state": "disabled",
+            "settings": {
+                "firstPartyTrackerCookiePolicy": {
+                    "threshold": 86400,
+                    "maxAge": 86400
+                }
+            },
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "clickToPlay": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "fingerprintingCanvas": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "fingerprintingAudio": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "fingerprintingTemporaryStorage": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "referrer": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "fingerprintingBattery": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "fingerprintingScreenSize": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "fingerprintingHardware": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "floc": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "gpc": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        },
+        "autofill": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
+        }
+    },
+    "version": 1635943904459,
+    "unprotectedTemporary": []
+}

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -127,7 +127,7 @@
             "settings": {
                 "scripts": [
                     {
-                        "domain": "skip.third-party.com",
+                        "domain": "^https?:\/\/([^/]+\.)?skip\.third-party\.com",
                         "reason": "Feature should not be disabled if requested by script from this domain"
                     }
                 ]

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -78,7 +78,7 @@
         "fingerprintingCanvas": {
             "state": "enabled",
             "settings": {
-                "aboutBlankEnabled": false
+                "aboutBlankEnabled": "disabled"
             },
             "exceptions": [
                 {

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -91,7 +91,10 @@
             "state": "enabled",
             "settings": {
                 "aboutBlankSites": [
-                    "blank-iframe.com"
+                    {
+                        "domain": "blank-iframe.com",
+                        "reason": "about blank iframes should not include this feature on this site"
+                    }
                 ]
             },
             "exceptions": [

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -127,7 +127,7 @@
             "settings": {
                 "scripts": [
                     {
-                        "domain": "^https?:\/\/([^/]+\\.)?skip\\.third-party\\.com",
+                        "domain": "^https?:\\/\\/([^/]+\\.)?skip\\.third-party\\.com",
                         "reason": "Feature should not be disabled if requested by script from this domain"
                     }
                 ]

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -124,12 +124,14 @@
         },
         "fingerprintingBattery": {
             "state": "enabled",
-            "scripts": [
-                {
-                    "domain": "skip.third-party.com",
-                    "reason": "Feature should not be disabled if requested by script from this domain"
-                }
-            ],
+            "settings": {
+                "scripts": [
+                    {
+                        "domain": "skip.third-party.com",
+                        "reason": "Feature should not be disabled if requested by script from this domain"
+                    }
+                ]
+            },
             "exceptions": [
                 {
                     "domain": "exception.com",

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -20,6 +20,10 @@
                 {
                     "domain": "exception.com",
                     "reason": "Feature should be disabled for given domain."
+                },
+                {
+                    "domain": "dont.block.co.uk",
+                    "reason": "Feature should be disabled for given domain."
                 }
             ]
         },

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -127,7 +127,7 @@
             "settings": {
                 "scripts": [
                     {
-                        "domain": "^https?:\/\/([^/]+\.)?skip\.third-party\.com",
+                        "domain": "^https?:\/\/([^/]+\\.)?skip\\.third-party\\.com",
                         "reason": "Feature should not be disabled if requested by script from this domain"
                     }
                 ]

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -77,7 +77,9 @@
         },
         "fingerprintingCanvas": {
             "state": "enabled",
-            "aboutBlankEnabled": false,
+            "settings": {
+                "aboutBlankEnabled": false
+            },
             "exceptions": [
                 {
                     "domain": "exception.com",
@@ -87,12 +89,14 @@
         },
         "fingerprintingAudio": {
             "state": "enabled",
-            "aboutBlankSites": [
-                {
-                    "domain": "blank-iframe.com",
-                    "reason": "about blank iframes should not include this feature on this site"
-                }
-            ],
+            "settings": {
+                "aboutBlankSites": [
+                    {
+                        "domain": "blank-iframe.com",
+                        "reason": "about blank iframes should not include this feature on this site"
+                    }
+                ]
+            },
             "exceptions": [
                 {
                     "domain": "exception.com",

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -91,10 +91,7 @@
             "state": "enabled",
             "settings": {
                 "aboutBlankSites": [
-                    {
-                        "domain": "blank-iframe.com",
-                        "reason": "about blank iframes should not include this feature on this site"
-                    }
+                    "blank-iframe.com"
                 ]
             },
             "exceptions": [

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -1,0 +1,189 @@
+{
+    "readme": "This configuration has all features enabled with individual exceptions for sites.",
+    "features": {
+        "https": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                },
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "contentBlocking": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "trackerAllowlist": {
+            "state": "enabled",
+            "settings": {
+                "allowlistedTrackers": {}
+            },
+            "exceptions": []
+        },
+        "trackingCookies3p": {
+            "state": "enabled",
+            "settings": {
+                "excludedCookieDomains": [
+                    {
+                        "domain": "exception.com",
+                        "reason": "Feature should be disabled for given domain."
+                    }
+                ]
+            },
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "trackingCookies1p": {
+            "state": "enabled",
+            "settings": {
+                "firstPartyTrackerCookiePolicy": {
+                    "threshold": 86400,
+                    "maxAge": 86400
+                }
+            },
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "clickToPlay": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "fingerprintingCanvas": {
+            "state": "enabled",
+            "aboutBlankEnabled": false,
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "fingerprintingAudio": {
+            "state": "enabled",
+            "aboutBlankSites": [
+                {
+                    "domain": "blank-iframe.com",
+                    "reason": "about blank iframes should not include this feature on this site"
+                }
+            ],
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "fingerprintingTemporaryStorage": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "referrer": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "fingerprintingBattery": {
+            "state": "enabled",
+            "scripts": [
+                {
+                    "domain": "skip.third-party.com",
+                    "reason": "Feature should not be disabled if requested by script from this domain"
+                }
+            ],
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "fingerprintingScreenSize": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "fingerprintingHardware": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "floc": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "gpc": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        },
+        "autofill": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
+        }
+    },
+    "version": 1635943904459,
+    "unprotectedTemporary": [
+        {
+            "domain": "global-exception.com",
+            "reason": "This exception should disable all features"
+        },
+        {
+            "domain": "dont.global-block.co.uk",
+            "reason": "This exception should disable all features"
+        }
+    ]
+}

--- a/privacy-configuration/config3_reference.json
+++ b/privacy-configuration/config3_reference.json
@@ -1,0 +1,7 @@
+{
+    "readme": "This configuration is missing features.",
+    "features": {
+    },
+    "version": 1635943904459,
+    "unprotectedTemporary": []
+}

--- a/privacy-configuration/test.json
+++ b/privacy-configuration/test.json
@@ -1,0 +1,629 @@
+{
+    "featuresDisabled": {
+        "name": "All features are disabled",
+        "desc": "Those tests use config1_reference.json where all features are disabled",
+        "referenceConfig": "config1_reference.json",
+        "tests": [
+            {
+                "name": "smarter encryption should be disabled",
+                "featureName": "https",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension"
+                ]
+            },
+            {
+                "name": "tracker blocking should be disabled",
+                "featureName": "contentBlocking",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker allowlisting should be disabled",
+                "featureName": "trackerAllowlist",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "blocking of third party tracking cookies should be disabled",
+                "featureName": "trackingCookies3p",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser"
+                ]
+            },
+            {
+                "name": "reducing expiry of first party tracking cookies should be disabled",
+                "featureName": "trackingCookies1p",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "macos-browser"
+                ]
+            },
+            {
+                "name": "click to load should be disabled",
+                "featureName": "clickToPlay",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for canvas should be disabled",
+                "featureName": "fingerprintingCanvas",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for audio should be disabled",
+                "featureName": "fingerprintingAudio",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for temporaryStorage should be disabled",
+                "featureName": "fingerprintingTemporaryStorage",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "referrer trimming should be disabled",
+                "featureName": "referrer",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for battery API should be disabled",
+                "featureName": "fingerprintingBattery",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for screen size API should be disabled",
+                "featureName": "fingerprintingScreenSize",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for hardware should be disabled",
+                "featureName": "fingerprintingHardware",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "FLoC protection should be disabled",
+                "featureName": "floc",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Global Privacy Control should be disabled",
+                "featureName": "gpc",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension"
+                ]
+            },
+            {
+                "name": "email autofill should be disabled",
+                "featureName": "autofill",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "windows-browser"
+                ]
+            }
+        ]
+    },
+    "featuresEnabled": {
+        "name": "All features are enabled",
+        "desc": "Those tests use config2_reference.json where all features are enabled",
+        "referenceConfig": "config2_reference.json",
+        "tests": [
+            {
+                "name": "smarter encryption should be enabled",
+                "featureName": "https",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension"
+                ]
+            },
+            {
+                "name": "tracker blocking should be enabled",
+                "featureName": "contentBlocking",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker allowlisting should be enabled",
+                "featureName": "trackerAllowlist",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "blocking of third party tracking cookies should be enabled",
+                "featureName": "trackingCookies3p",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser"
+                ]
+            },
+            {
+                "name": "reducing expiry of first party tracking cookies should be enabled",
+                "featureName": "trackingCookies1p",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "macos-browser"
+                ]
+            },
+            {
+                "name": "click to load should be enabled",
+                "featureName": "clickToPlay",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for canvas should be enabled",
+                "featureName": "fingerprintingCanvas",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for audio should be enabled",
+                "featureName": "fingerprintingAudio",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for temporaryStorage should be enabled",
+                "featureName": "fingerprintingTemporaryStorage",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "referrer trimming should be enabled",
+                "featureName": "referrer",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for battery API should be enabled",
+                "featureName": "fingerprintingBattery",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for screen size API should be enabled",
+                "featureName": "fingerprintingScreenSize",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "fingerprinting protection for hardware should be enabled",
+                "featureName": "fingerprintingHardware",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "FLoC protection should be enabled",
+                "featureName": "floc",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Global Privacy Control should be enabled",
+                "featureName": "gpc",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension"
+                ]
+            },
+            {
+                "name": "email autofill should be enabled",
+                "featureName": "autofill",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "windows-browser"
+                ]
+            }
+        ]
+    },
+    "localExceptions": {
+        "name": "Per-feature exceptions should match correctly",
+        "desc": "Those tests use config2_reference.json where all features are enabled",
+        "referenceConfig": "config2_reference.json",
+        "tests": [
+            {
+                "name": "tracker blocking should be disabled due to a local exception",
+                "featureName": "contentBlocking",
+                "siteURL": "https://exception.com",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should be disabled due to a local exception - subdomains should also match",
+                "featureName": "contentBlocking",
+                "siteURL": "https://sub.exception.com",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should be disabled due to a local exception - full url",
+                "featureName": "contentBlocking",
+                "siteURL": "http://a.b.exception.com/some/path?query=value#thing",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should NOT be disabled - domain name in the path/query",
+                "featureName": "contentBlocking",
+                "siteURL": "https://nope.com/path/?site_url=exception.com",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should NOT be disabled - domain name is only a partial match",
+                "featureName": "contentBlocking",
+                "siteURL": "https://exception.com.pl/",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should be disabled due to a local exception",
+                "featureName": "contentBlocking",
+                "siteURL": "https://dont.block.co.uk",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should NOT be disabled - exception is more narrow (subdomain)",
+                "featureName": "contentBlocking",
+                "siteURL": "https://block.co.uk",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            }
+        ]
+    },
+    "globalExceptions": {
+        "name": "Global exceptions should match correctly",
+        "desc": "Those tests use config2_reference.json where all features are enabled",
+        "referenceConfig": "config2_reference.json",
+        "tests": [
+            {
+                "name": "tracker blocking should be disabled due to a global exception",
+                "featureName": "contentBlocking",
+                "siteURL": "https://global-exception.com",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should be disabled due to a global exception - subdomains should also match",
+                "featureName": "contentBlocking",
+                "siteURL": "https://sub.global-exception.com",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should be disabled due to a global exception - full url",
+                "featureName": "contentBlocking",
+                "siteURL": "http://a.b.global-exception.com/some/path?query=value#thing",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should NOT be disabled - domain name in the path/query",
+                "featureName": "contentBlocking",
+                "siteURL": "https://nope.com/path/?site_url=global-exception.com",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should NOT be disabled - domain name is only a partial match",
+                "featureName": "contentBlocking",
+                "siteURL": "https://global-exception.com.pl/",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should be disabled due to a global exception",
+                "featureName": "contentBlocking",
+                "siteURL": "https://dont.global-block.co.uk",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "tracker blocking should NOT be disabled - exception is more narrow (subdomain)",
+                "featureName": "contentBlocking",
+                "siteURL": "https://block.co.uk",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": []
+            }
+        ]
+    },
+    "aboutBlank": {
+        "name": "Some features are disabled in blank iframes",
+        "desc": "Those tests use config2_reference.json where all features are enabled",
+        "referenceConfig": "config2_reference.json",
+        "tests": [
+            {
+                "name": "Features should be enabled by default in blank iframes",
+                "featureName": "fingerprintingTemporaryStorage",
+                "siteURL": "https://example.org",
+                "frameURL": "about:blank",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Features should be disabled in blank iframes if specified by the feature",
+                "featureName": "fingerprintingCanvas",
+                "siteURL": "https://example.org",
+                "frameURL": "about:blank",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Features should NOT be disabled in iframes that are not blank",
+                "featureName": "fingerprintingCanvas",
+                "siteURL": "https://example.org",
+                "frameURL": "https://inner.com",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Features should be disabled in blank iframes if they match the blocklist",
+                "featureName": "fingerprintingAudio",
+                "siteURL": "blank-iframe.com",
+                "frameURL": "about:blank",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Features should NOT be disabled in blank iframes if they don't match the blocklist",
+                "featureName": "fingerprintingAudio",
+                "siteURL": "https://example.org",
+                "frameURL": "about:blank",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            }
+        ]
+    },
+    "script": {
+        "name": "Some protections are disabled for some scripts",
+        "desc": "Those tests use config2_reference.json where all features are enabled",
+        "referenceConfig": "config2_reference.json",
+        "tests": [
+            {
+                "name": "Feature should be disabled if script matches exception",
+                "featureName": "fingerprintingBattery",
+                "siteURL": "https://example.org",
+                "scriptURL": "https://skip.third-party.com/script.js",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Feature should be disabled if script matches exception - subdomain should match",
+                "featureName": "fingerprintingBattery",
+                "siteURL": "https://example.org",
+                "scriptURL": "https://also.skip.third-party.com/script.js",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Feature should NOT be disabled - domain name in the path/query",
+                "featureName": "fingerprintingBattery",
+                "siteURL": "https://example.org",
+                "scriptURL": "https://tracker.com/script.js?fake=skip.third-party.com",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            },
+            {
+                "name": "Feature should NOT be disabled - exception is more narrow (subdomain)",
+                "featureName": "fingerprintingBattery",
+                "siteURL": "https://example.org",
+                "scriptURL": "https://third-party.com/script.js",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
+                ]
+            }
+        ]
+    },
+    "missingFeature": {
+        "name": "Protections are expected to be disabled if they are missing from the config file.",
+        "desc": "Those tests use config3_reference.json where 'features' object is empty",
+        "referenceConfig": "config3_reference.json",
+        "tests": [
+            {
+                "name": "Feature should be disabled if it's not mentioned in the config file",
+                "featureName": "contentBlocking",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": []
+            },
+    }
+}

--- a/privacy-configuration/tests.json
+++ b/privacy-configuration/tests.json
@@ -624,6 +624,7 @@
                 "siteURL": "https://example.org",
                 "expectFeatureEnabled": false,
                 "exceptPlatforms": []
-            },
+            }
+        ]
     }
 }

--- a/privacy-configuration/tests.json
+++ b/privacy-configuration/tests.json
@@ -523,7 +523,7 @@
             {
                 "name": "Features should be disabled in blank iframes if they match the blocklist",
                 "featureName": "fingerprintingAudio",
-                "siteURL": "blank-iframe.com",
+                "siteURL": "https://blank-iframe.com",
                 "frameURL": "about:blank",
                 "expectFeatureEnabled": false,
                 "exceptPlatforms": [

--- a/privacy-configuration/tests.json
+++ b/privacy-configuration/tests.json
@@ -402,7 +402,7 @@
                 "exceptPlatforms": []
             },
             {
-                "name": "tracker blocking should be disabled due to a local exception",
+                "name": "tracker blocking should be disabled due to a local exception - exception domain with a subdomain",
                 "featureName": "contentBlocking",
                 "siteURL": "https://dont.block.co.uk",
                 "expectFeatureEnabled": false,


### PR DESCRIPTION
NOTE - might be worth merging https://github.com/duckduckgo/privacy-reference-tests/pull/10 first to make sure that this PR passes linting (I tested locally but you never know).

Implementation guidelines for the feature are here: https://app.asana.com/0/1198207348643509/1200553491728590/f

Test implementation in the web extension is waiting here: https://github.com/duckduckgo/duckduckgo-privacy-extension/compare/konrad/reference-tests-config

This follows the new format outlined here: https://app.asana.com/0/0/1201321554045382/f