### PR TITLE
Provide surrogates file in a different format

### DIFF
--- a/privacy-configuration/README.MD
+++ b/privacy-configuration/README.MD
@@ -1,4 +1,4 @@
-# Tracker blocking related tests
+# Privacy Configuration Tests
 
 Privacy Feature: https://app.asana.com/0/1198207348643509/1199981227466169/f
 

--- a/privacy-configuration/README.MD
+++ b/privacy-configuration/README.MD
@@ -1,4 +1,4 @@
-# Privacy Configuration Tests
+# Tracker blocking related tests
 
 Privacy Feature: https://app.asana.com/0/1198207348643509/1199981227466169/f
 

--- a/tracker-radar-tests/TR-domain-matching/README.md
+++ b/tracker-radar-tests/TR-domain-matching/README.md
@@ -1,4 +1,4 @@
-# Feature Name Tests
+# Tracker Blocking Related Tests
 
 This folder contains tests for the follwoing features:
 

--- a/tracker-radar-tests/TR-domain-matching/README.md
+++ b/tracker-radar-tests/TR-domain-matching/README.md
@@ -1,0 +1,37 @@
+# Feature Name Tests
+
+This folder contains tests for the follwoing features:
+
+- Tracker blocking - https://app.asana.com/0/1198207348643509/1199103718890844
+- CNAME cloaking - https://app.asana.com/0/1198207348643509/1199093921854069
+- Tracker allowlist feature in the  Privacy Configuration - https://app.asana.com/0/1198207348643509/1199981227466169
+- Surrogates - https://app.asana.com/0/1198207348643509/1199093921854088/f
+
+## Structure
+
+### Tracker blocking, CNAME cloaking and surrogates
+
+Files in the folder:
+- `domain_matching_tests.json` - tests for tracker blocking, CNAME cloaking and surrogates
+- `tracker_radar_reference.json` - reference blocklist file that should be used with `domain_matching_tests.json` tests
+- `surrogates.txt` - reference surrogates file that should be used with `domain_matching_tests.json` tests
+- `surrogates.js` - web extension friendly version of `surrogates.txt` (other platforms should use `surrogates.txt`)
+
+Test suite specific fields:
+- `siteURL` - URL - page where request in question is made
+- `requestURL` - URL - request in question
+- `requestType` - mostly "image" or "script", but can be any of https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType - type of the resource being fetched
+- `expectAction` - one of: null (don't block, not on a blocklist), ignore (don't block, exception), block, redirect (when should be repalced with a surrogate) - expected action that client should take
+- `expectRedirect` - string - only if action is "redirect" this should contain url of the surrogate (base64'ed version of the correct surrogate file)
+
+### Privacy config allowlist
+
+Files in the folder:
+- `tracker_allowlist_matching_tests.json` - test for tracker allowlist feature - ⚠️ those tests don't follow the format used by other tests ⚠️ 
+- `tracker_allowlist_tds_references.json` - reference blocklist file that should be used with `tracker_allowlist_matching_tests.json` tests
+- `tracker_allowlist_references.json` - reference privacy config file that should be used with `tracker_allowlist_matching_tests.json` tests
+
+Test suite specific fields:
+- `site` - URL - page where request in question is made
+- `request` - URL - request in question
+- `isAllowlisted` - bool - if requestis expected to be allowlisted or not

--- a/tracker-radar-tests/TR-domain-matching/README.md
+++ b/tracker-radar-tests/TR-domain-matching/README.md
@@ -15,7 +15,6 @@ Files in the folder:
 - `domain_matching_tests.json` - tests for tracker blocking, CNAME cloaking and surrogates
 - `tracker_radar_reference.json` - reference blocklist file that should be used with `domain_matching_tests.json` tests
 - `surrogates.txt` - reference surrogates file that should be used with `domain_matching_tests.json` tests
-- `surrogates.js` - web extension friendly version of `surrogates.txt` (other platforms should use `surrogates.txt`)
 
 Test suite specific fields:
 - `siteURL` - URL - page where request in question is made

--- a/tracker-radar-tests/TR-domain-matching/surrogates.js
+++ b/tracker-radar-tests/TR-domain-matching/surrogates.js
@@ -1,3 +1,0 @@
-module.exports = {
-    surrogates: 'surrogates.test/tracker application/javascript\n(function() {var tracker=true})();'
-}

--- a/tracker-radar-tests/TR-domain-matching/surrogates.txt
+++ b/tracker-radar-tests/TR-domain-matching/surrogates.txt
@@ -1,0 +1,6 @@
+# This file contains "surrogates". Surrogates are small scripts that our apps and extensions serve in place of trackers that cause site breakage when blocked.
+# Learn more: https://github.com/duckduckgo/tracker-surrogates
+surrogates.test/tracker application/javascript
+(function() {
+    var tracker=true
+})();

--- a/tracker-radar-tests/TR-domain-matching/surrogates.txt
+++ b/tracker-radar-tests/TR-domain-matching/surrogates.txt
@@ -1,6 +1,4 @@
 # This file contains "surrogates". Surrogates are small scripts that our apps and extensions serve in place of trackers that cause site breakage when blocked.
 # Learn more: https://github.com/duckduckgo/tracker-surrogates
 surrogates.test/tracker application/javascript
-(function() {
-    var tracker=true
-})();
+(function() {var tracker=true})();

--- a/tracker-radar-tests/TR-domain-matching/surrogates.txt
+++ b/tracker-radar-tests/TR-domain-matching/surrogates.txt
@@ -2,3 +2,8 @@
 # Learn more: https://github.com/duckduckgo/tracker-surrogates
 surrogates.test/tracker application/javascript
 (function() {var tracker=true})();
+
+something.else.com/script.js application/javascript
+(() => {
+    'use strict';
+})();


### PR DESCRIPTION
`surrogates.js` is in web-extension friendly format, but this format is hard to process for other platforms (it's a JS file). This PR adds `surrogates.txt` file which is closer to the real thing https://duckduckgo.com/contentblocking.js?l=surrogates . Additionally, I wrote up a small readme so that we provide some minimal integration instructions.