### PR TITLE
Add an edge case where tracker is CNAME'd to a safe domain

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -108,6 +108,13 @@
                 "expectAction": "block"
             },
             {
+                "name": "no blocklist entry for an uncloacked domain - request should not be blocked",
+                "siteURL": "https://randomsite123.com/",
+                "requestURL": "https://domain.cloaked.test/some/script.js",
+                "requestType": "script",
+                "expectAction": null
+            },
+            {
                 "name": "sub.ignore loads tracker",
                 "siteURL": "https://sub.ignore.test/",
                 "requestURL": "https://bad.third-party.site/",

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -77,6 +77,13 @@
                 "expectAction": "block"
             },
             {
+                "name": "uncloacked tracker should contain original path and be checked against the ignore rules",
+                "siteURL": "https://randomsite123.com/",
+                "requestURL": "https://bad.cnames.test/breakage",
+                "requestType": "script",
+                "expectAction": "ignore"
+            },
+            {
                 "name": "random allows sub.cname tracker",
                 "siteURL": "https://randomsite123.com/",
                 "requestURL": "https://also.bad.cnames.test/something",

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -94,6 +94,13 @@
                 "expectAction": null
             },
             {
+                "name": "tracker.test CNAME'd to ignore.test should still be blocked",
+                "siteURL": "https://randomsite123.com/",
+                "requestURL": "https://fake-ignore.tracker.test/spy/script.js",
+                "requestType": "script",
+                "expectAction": "block"
+            },
+            {
                 "name": "sub.ignore loads tracker",
                 "siteURL": "https://sub.ignore.test/",
                 "requestURL": "https://bad.third-party.site/",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -126,7 +126,8 @@
         }
     },
     "cnames": {
-        "bad.cnames.test": "cname.tracker.test"
+        "bad.cnames.test": "cname.tracker.test",
+        "fake-ignore.tracker.test": "ignore.test"
     },
     "domains": {
         "bad.third-party.site": "Test Site for Tracker Blocking",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -132,7 +132,8 @@
     },
     "cnames": {
         "bad.cnames.test": "cname.tracker.test",
-        "fake-ignore.tracker.test": "tracker.ignore.test"
+        "fake-ignore.tracker.test": "tracker.ignore.test",
+        "domain.cloaked.test": "some.other.unknown.test"
     },
     "domains": {
         "bad.third-party.site": "Test Site for Tracker Blocking",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -58,7 +58,12 @@
             "fingerprinting": 3,
             "cookies": 0.1,
             "categories": [],
-            "default": "block"
+            "default": "block",
+            "rules": [
+                {
+                    "rule": "tracker\\.test\\/breakage"
+                }
+            ]
         },
         "ignore.test": {
             "domain": "ignore.test",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -127,7 +127,7 @@
     },
     "cnames": {
         "bad.cnames.test": "cname.tracker.test",
-        "fake-ignore.tracker.test": "ignore.test"
+        "fake-ignore.tracker.test": "tracker.ignore.test"
     },
     "domains": {
         "bad.third-party.site": "Test Site for Tracker Blocking",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -61,6 +61,7 @@
             "default": "block",
             "rules": [
                 {
+                    "action": "ignore",
                     "rule": "tracker\\.test\\/breakage"
                 }
             ]


### PR DESCRIPTION
Two tests:

- Known tracker can be CNAME'd to a domain that we don't block in which case we should still block it.
- Path from the original request should carry over to the uncloaked url and be checked against the `rules`
- plus a test for when cname entry maps to domain that doesn't have blocklist entry

Discussion: https://app.asana.com/0/0/1200328036456971/1201419292358852/f