### PR TITLE
Tracker blocking test fix and Tracker Radar sanity checks

### DIFF
--- a/_scripts/helpers/tracker-radar-checks.js
+++ b/_scripts/helpers/tracker-radar-checks.js
@@ -1,3 +1,9 @@
+/**
+ * Basic sanity checks for Tracker Radar blocklists. Those are usually crafted by hend for purpose of testing and can have errors.
+ * 
+ * @param {{trackers: Object<string, any>, entities: Object<string, any>, domains: Object<string, string>}} trackerRadarObject 
+ * @returns {Array<{message:string, location: string}>}
+ */
 module.exports = (trackerRadarObject) => {
     const errors = [];
 

--- a/_scripts/helpers/tracker-radar-checks.js
+++ b/_scripts/helpers/tracker-radar-checks.js
@@ -1,0 +1,37 @@
+module.exports = (trackerRadarObject) => {
+    const errors = [];
+
+    function error(message, ...location) {
+        errors.push({message, location: location.join(' ↣ ')});
+    }
+
+    Object.keys(trackerRadarObject.trackers).forEach(domain => {
+        const tracker = trackerRadarObject.trackers[domain];
+
+        if (tracker.domain !== domain) {
+            error('"domain" value doesn\'t match key value', 'trackers', domain);
+        }
+
+        const trackersOwnerName = tracker.owner.name;
+
+        if (!trackerRadarObject.entities[trackersOwnerName]) {
+            error('owner name missing from "entities" object', 'trackers', domain);
+        } else {
+            if (!trackerRadarObject.entities[trackersOwnerName].domains.includes(domain)) {
+                error(`missing domain: ${domain}`, 'entities', trackersOwnerName);
+            }
+        }
+
+        const domainsOwnerName = trackerRadarObject.domains[domain];
+
+        if (!domainsOwnerName) {
+            error('domain missing form "domains" object', 'trackers', domain);
+        } else {
+            if (domainsOwnerName !== trackersOwnerName) {
+                error('owner name doesn\'t match name of the owner in "domains" object', 'trackers', domain);
+            }
+        }
+    });
+
+    return errors;
+}

--- a/_scripts/helpers/tracker-radar-checks.js
+++ b/_scripts/helpers/tracker-radar-checks.js
@@ -28,6 +28,12 @@ module.exports = (trackerRadarObject) => {
             }
         }
 
+        const entityOwners = Object.keys(trackerRadarObject.entities).filter(owner => trackerRadarObject.entities[owner].domains.includes(domain));
+
+        if (entityOwners.length > 1) {
+            error(`${domain} has multiple owners`, 'entities', entityOwners[0]);
+        }
+
         const domainsOwnerName = trackerRadarObject.domains[domain];
 
         if (!domainsOwnerName) {

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -214,7 +214,7 @@
             },
             {
                 "name": "skip surrogates for same entity",
-                "siteURL": "https://tracker.test/",
+                "siteURL": "https://other-surrogates.test/",
                 "requestURL": "https://surrogates.test/tracker?abc=2",
                 "requestType": "script",
                 "expectAction": "ignore"

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -116,8 +116,7 @@
                 "bad.third-party.site",
                 "broken.third-party.site",
                 "third-party.site",
-                "tracker.test",
-                "surrogates.test"
+                "tracker.test"
             ],
             "prevalence": 0.1,
             "displayName": "Test Site for Tracker Blocking"

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -69,8 +69,8 @@
         "ignore.test": {
             "domain": "ignore.test",
             "owner": {
-                "name": "Test Site for Tracker Blocking",
-                "displayName": "ignore Site",
+                "name": "Ignore Site for Tracker Blocking",
+                "displayName": "Ignore Site",
                 "privacyPolicy": "",
                 "url": "http://ignore.test"
             },
@@ -88,8 +88,8 @@
         "surrogates.test": {
             "domain": "surrogates.test",
             "owner": {
-                "name": "Test Site for surrogates",
-                "displayName": "Bad Third Party Site",
+                "name": "Test Site for Surrogates",
+                "displayName": "Surrogates Site",
                 "privacyPolicy": "",
                 "url": "http://surrogates.test"
             },
@@ -122,13 +122,20 @@
             "prevalence": 0.1,
             "displayName": "Test Site for Tracker Blocking"
         },
-        "ignore Site for Tracker Blocking": {
+        "Ignore Site for Tracker Blocking": {
             "domains": [
                 "ignore.test",
                 "sub.ignore.test"
             ],
             "prevalence": 0.1,
-            "displayName": "ignore Site for Tracker Blocking"
+            "displayName": "Ignore Site for Tracker Blocking"
+        },
+        "Test Site for Surrogates": {
+            "domains": [
+                "surrogates.test"
+            ],
+            "prevalence": 0.1,
+            "displayName": "Test Site for Surrogates"
         }
     },
     "cnames": {
@@ -141,8 +148,8 @@
         "broken.third-party.site": "Test Site for Tracker Blocking",
         "third-party.site": "Test Site for Tracker Blocking",
         "tracker.test": "Test Site for Tracker Blocking",
-        "ignore.test": "ignore Site for Tracker Blocking",
-        "sub.ignore.test": "ignore Site for Tracker Blocking",
-        "surrogates.test": "Test Site for surrogates"
+        "ignore.test": "Ignore Site for Tracker Blocking",
+        "sub.ignore.test": "Ignore Site for Tracker Blocking",
+        "surrogates.test": "Test Site for Surrogates"
     }
 }

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -132,6 +132,7 @@
         },
         "Test Site for Surrogates": {
             "domains": [
+                "other-surrogates.test",
                 "surrogates.test"
             ],
             "prevalence": 0.1,
@@ -150,6 +151,7 @@
         "tracker.test": "Test Site for Tracker Blocking",
         "ignore.test": "Ignore Site for Tracker Blocking",
         "sub.ignore.test": "Ignore Site for Tracker Blocking",
-        "surrogates.test": "Test Site for Surrogates"
+        "surrogates.test": "Test Site for Surrogates",
+        "other-surrogates.test": "Test Site for Surrogates"
     }
 }


### PR DESCRIPTION
@marcosholgado found an error in reference tracker radar blocklist that was causing one of the test to fail on Android. This PR fixes the issue and adds basic sanity checks for all `tracker_radar*` files (since those are usually crafted by hand for testing it's easy to make a mistake).