### PR TITLE
Change tests for Android and add eme

### DIFF
--- a/privacy-configuration/config1_reference.json
+++ b/privacy-configuration/config1_reference.json
@@ -160,6 +160,15 @@
                     "reason": "Exception should not alter feature's 'disabled' state"
                 }
             ]
+        },
+        "eme": {
+            "state": "disabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Exception should not alter feature's 'disabled' state"
+                }
+            ]
         }
     },
     "version": 1635943904459,

--- a/privacy-configuration/config2_reference.json
+++ b/privacy-configuration/config2_reference.json
@@ -183,6 +183,15 @@
                     "reason": "Feature should be disabled for given domain."
                 }
             ]
+        },
+        "eme": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "exception.com",
+                    "reason": "Feature should be disabled for given domain."
+                }
+            ]
         }
     },
     "version": 1635943904459,

--- a/privacy-configuration/tests.json
+++ b/privacy-configuration/tests.json
@@ -47,7 +47,8 @@
                 "exceptPlatforms": [
                     "safari-extension",
                     "ios-browser",
-                    "macos-browser"
+                    "macos-browser",
+                    "android-browser"
                 ]
             },
             {
@@ -175,6 +176,19 @@
                 "expectFeatureEnabled": false,
                 "exceptPlatforms": [
                     "safari-extension",
+                    "windows-browser",
+                    "android-browser"
+                ]
+            },
+            {
+                "name": "eme should be disabled",
+                "featureName": "eme",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": false,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "macos-browser",
                     "windows-browser"
                 ]
             }
@@ -228,6 +242,7 @@
                 "exceptPlatforms": [
                     "safari-extension",
                     "ios-browser",
+                    "android-browser",
                     "macos-browser"
                 ]
             },
@@ -356,6 +371,19 @@
                 "expectFeatureEnabled": true,
                 "exceptPlatforms": [
                     "safari-extension",
+                    "windows-browser",
+                    "android-browser"
+                ]
+            },
+            {
+                "name": "eme should be enabled",
+                "featureName": "eme",
+                "siteURL": "https://example.org",
+                "expectFeatureEnabled": true,
+                "exceptPlatforms": [
+                    "safari-extension",
+                    "ios-browser",
+                    "macos-browser",
                     "windows-browser"
                 ]
             }

--- a/privacy-configuration/tests.json
+++ b/privacy-configuration/tests.json
@@ -189,7 +189,8 @@
                     "safari-extension",
                     "ios-browser",
                     "macos-browser",
-                    "windows-browser"
+                    "windows-browser",
+                    "web-extension"
                 ]
             }
         ]
@@ -384,7 +385,8 @@
                     "safari-extension",
                     "ios-browser",
                     "macos-browser",
-                    "windows-browser"
+                    "windows-browser",
+                    "web-extension"
                 ]
             }
         ]


### PR DESCRIPTION
https://app.asana.com/0/1125189844152671/1201514178819251

This PR adds eme as a new test only for Android and it excludes Android from the autofill tests (not yet implemented) and trackingCookies1p