### PR TITLE
Fix broken sites json

### DIFF
--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -17,7 +17,7 @@
                     {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
                     {"name": "upgradedHttps", "value": "true"},
                     {"name": "tds", "value": "abc123"},
-                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test,surrogate.domain.test"},
+                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test"}
                 ],
                 "exceptPlatforms": []
@@ -53,7 +53,7 @@
                 "blocklistVersion": "abc123",
                 "manufacturer": "IBM",
                 "model": "305 RAMAC",
-                "os": "OS/2",
+                "os": "12",
                 "gpcEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
@@ -61,11 +61,11 @@
                     {"name": "siteUrl", "value": "http%3A%2F%2Funsafe.example.test%2F"},
                     {"name": "upgradedHttps", "value": "false"},
                     {"name": "tds", "value": "abc123"},
-                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test,surrogate.domain.test"},
+                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test"},
                     {"name": "manufacturer", "value": "IBM"},
                     {"name": "model", "value": "305 RAMAC"},
-                    {"name": "os", "value": "OS%2F2"},
+                    {"name": "os", "value": "12"},
                     {"name": "gpc", "value": "true"}
                 ],
                 "exceptPlatforms": [


### PR DESCRIPTION
Task: https://app.asana.com/0/1125189844152671/1201618190568577

A couple of changes:

1. Remove surrogates from the blocked trackers list
2. Change the specific os parameter for mobile to a number (otherwise crashes when the app tries to convert into a number) because the os is always a number.