### PR TITLE
TR Domain Matching: verify ports are ignored when matching rules

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -209,6 +209,13 @@
                 "requestURL": "https://ignore.test/tracker?abc=2",
                 "requestType": "script",
                 "expectAction": "block"
+            },
+            {
+                "name": "ports are ignored when matching rules",
+                "siteURL": "https://random.test/",
+                "requestURL": "https://bad.third-party.site:8080/ignore",
+                "requestType": "script",
+                "expectAction": "ignore"
             }
         ]
     },


### PR DESCRIPTION
Added a test to verify an edgecase - ports should be stripped when Regex matching a rule.