### PR TITLE
Test Surrogate rules that match an exception

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -263,6 +263,20 @@
                 "requestURL": "https://surrogates.test/anothertracker?abc=2",
                 "requestType": "script",
                 "expectAction": "block"
+            },
+            {
+                "name": "ignore on default-block tracker's surrogates that match rule exception",
+                "siteURL": "https://exceptedfromsurrogates.org/random",
+                "requestURL": "https://blockedsurrogates.test/tracker?abc=2",
+                "requestType": "script",
+                "expectAction": "ignore"
+            },
+            {
+                "name": "ignore on default-ignore tracker's surrogates that match rule exception",
+                "siteURL": "https://exceptedfromsurrogates.org/random",
+                "requestURL": "https://surrogates.test/tracker?abc=2",
+                "requestType": "script",
+                "expectAction": "ignore"
             }
         ]
     }

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -100,7 +100,12 @@
             "rules": [
                 {
                     "rule": "surrogates\\.test\\/tracker",
-                    "surrogate": "tracker"
+                    "surrogate": "tracker",
+                    "exceptions": {
+                        "domains": [
+                            "exceptedfromsurrogates.org"
+                        ]
+                    }
                 },
                 {
                     "rule": "surrogates\\.test\\/anothertracker",
@@ -108,6 +113,31 @@
                 }
             ],
             "default": "ignore"
+        },
+        "blockedsurrogates.test": {
+            "domain": "blockedsurrogates.test",
+            "owner": {
+                "name": "Test Site for Surrogates With Default Block Action",
+                "displayName": "Surrogates Site",
+                "privacyPolicy": "",
+                "url": "http://blockedsurrogates.test"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 3,
+            "cookies": 0.1,
+            "categories": [],
+            "rules": [
+                {
+                    "rule": "blockedsurrogates\\.test\\/tracker",
+                    "surrogate": "tracker",
+                    "exceptions": {
+                        "domains": [
+                            "exceptedfromsurrogates.org"
+                        ]
+                    }
+                }
+            ],
+            "default": "block"
         }
     },
     "entities": {
@@ -132,8 +162,9 @@
         "Test Site for Surrogates": {
             "domains": [
                 "other-surrogates.test",
-                "surrogates.test"
-            ],
+                "surrogates.test",
+                "blockedsurrogates.test"
+              ],
             "prevalence": 0.1,
             "displayName": "Test Site for Surrogates"
         }
@@ -151,6 +182,7 @@
         "ignore.test": "Ignore Site for Tracker Blocking",
         "sub.ignore.test": "Ignore Site for Tracker Blocking",
         "surrogates.test": "Test Site for Surrogates",
-        "other-surrogates.test": "Test Site for Surrogates"
+        "other-surrogates.test": "Test Site for Surrogates",
+        "blockedsurrogates.test": "Test Site for Surrogates"
     }
 }

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -117,7 +117,7 @@
         "blockedsurrogates.test": {
             "domain": "blockedsurrogates.test",
             "owner": {
-                "name": "Test Site for Surrogates With Default Block Action",
+                "name": "Test Site for Surrogates",
                 "displayName": "Surrogates Site",
                 "privacyPolicy": "",
                 "url": "http://blockedsurrogates.test"


### PR DESCRIPTION
Added two test cases that ensure that requests that match a Surrogate rule with matching exception are ignored in Trackers that have both the default ignore and block action.