### PR TITLE
Add stub package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "privacy-reference-tests",
+    "version": "0.1.0",
+    "description": "Test metadata used by DuckDuckGo apps and extensions to verify implementation of privacy features.",
+    "license": "Apache-2.0",
+    "repository": "duckduckgo/privacy-reference-tests"
+}


### PR DESCRIPTION
Add a package.json file so that privacy-reference-tests can be
conveniently included as a dependency from other npm packages.