### PR TITLE
Exclude Chrome MV3 from WebSocket Smarter Encryption test cases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Your tests will require some custom fields to set the stage for the test e.g. `"
 
 If test should be skipped on some platforms, e.g. because of the known limitations of the platform, please specify excepted platforms via `exceptPlatforms` field. Possible options are:
 
-- "web-extension" - our [Chrome/Firefox/Edge/Brave extension](https://github.com/duckduckgo/duckduckgo-privacy-extension)
+- "web-extension" & "web-extension-mv3" - our [Chrome/Firefox/Edge/Brave extension](https://github.com/duckduckgo/duckduckgo-privacy-extension)
 - "safari-extension" - our [Safari extension](https://github.com/duckduckgo/privacy-essentials-safari)
 - "ios-browser" - our [iOS application](https://github.com/duckduckgo/iOS)
 - "android-browser" - our [Android application](https://github.com/duckduckgo/Android)

--- a/_scripts/schemas/tests.json
+++ b/_scripts/schemas/tests.json
@@ -21,7 +21,7 @@
                             "exceptPlatforms": {
                                 "type": "array",
                                 "items": {
-                                    "enum": ["ios-browser", "android-browser", "macos-browser", "windows-browser", "web-extension", "safari-extension"] 
+                                    "enum": ["ios-browser", "android-browser", "macos-browser", "windows-browser", "web-extension", "safari-extension", "web-extension-mv3"]
                                 }
                             }
                         },

--- a/https-upgrades/tests.json
+++ b/https-upgrades/tests.json
@@ -146,7 +146,8 @@
                 "expectURL": "wss://fifth-test.com/path/socket?search=query&another=one#fragment",
                 "exceptPlatforms": [
                     "android-browser",
-                    "ios-browser"
+                    "ios-browser",
+                    "web-extension-mv3"
                 ]
             },
             {


### PR DESCRIPTION
The declarativeNetRequest API does not yet support upgrading insecure
WebSocket requests[1]. So for now, disable those test cases for the
Chrome MV3 platform.

1 - https://crbug.com/1231254