### PR TITLE
Add plain-text domains lists for the Smarter Encryption tests

### DIFF
--- a/https-upgrades/README.md
+++ b/https-upgrades/README.md
@@ -22,6 +22,8 @@ Files in the folder:
 - `https_bloomfilter_spec_reference.json` - specification of the `.bin` bloom filter
 - `https_negative_allowlist_reference.json` - inverse/negative boom filter with hostnames that should not be upgraded
 - `https_negative_bloomfilter_reference.json` - allowlist to the negative bloom filter with hostnames that should be upgraded
+ - `https_upgrade_hostnames.txt` - plaintext list of domains that should be upgraded
+ - `https_dont_upgrade_hostnames.txt` - plaintext list of domains that should not be upgraded
 
 Test suite specific fields:
 

--- a/https-upgrades/https_dont_upgrade_hostnames.txt
+++ b/https-upgrades/https_dont_upgrade_hostnames.txt
@@ -1,0 +1,2 @@
+negativetest.com
+thirdnegative.com

--- a/https-upgrades/https_upgrade_hostnames.txt
+++ b/https-upgrades/https_upgrade_hostnames.txt
@@ -1,0 +1,6 @@
+firsttest.com
+secure.thirdtest.com
+s.fourthtest.com
+fifth-test.com
+a.b.c.d.e.sixthtest.com
+s.secondnegative.com


### PR DESCRIPTION
For platforms not using the Bloom Filters for Smarter Encryption, it
is useful to also include the list of included/excluded domains