### PR TITLE
Add missing & to URL param tests

### DIFF
--- a/url-parameters/tests.json
+++ b/url-parameters/tests.json
@@ -124,13 +124,13 @@
             {
                 "name": "Unremoved parameters that are url encoded are not modified.",
                 "testURL": "http://www.example.com/test.html?utm_medium=test&c=%7B%7D&d=20220406%2Fus-east-1",
-                "expectURL": "http://www.example.com/test.html?c=%7B%7Dd=20220406%2Fus-east-1",
+                "expectURL": "http://www.example.com/test.html?c=%7B%7D&d=20220406%2Fus-east-1",
                 "exceptPlatforms": []
             },
             {
                 "name": "A URL with no tracking parameters but contains url encoded parameters is not modified.",
                 "testURL": "http://www.example.com/test.html?c=%7B%7D&d=20220406%2Fus-east-1",
-                "expectURL": "http://www.example.com/test.html?c=%7B%7Dd=20220406%2Fus-east-1",
+                "expectURL": "http://www.example.com/test.html?c=%7B%7D&d=20220406%2Fus-east-1",
                 "exceptPlatforms": []
             }
         ]


### PR DESCRIPTION
Since the expected params should not be modified, these two test cases should have an "&" separating the parameters in the `expectUrl`.

Tested on Apple + Android ✅