### PR TITLE
Cookie feature rename

### DIFF
--- a/block-third-party-tracking-cookies/config_reference.json
+++ b/block-third-party-tracking-cookies/config_reference.json
@@ -17,6 +17,32 @@
                 }
             ],
             "state": "enabled"
+        },
+        "nonTracking3pCookies": {
+            "state": "disabled",
+            "settings": {
+                "excludedCookieDomains": [ ]
+            },
+            "exceptions": [ ]
+        },
+        "cookie": {
+            "state": "enabled",
+            "settings": {
+                "excludedCookieDomains": [
+                    {
+                        "domain": "excluded-cookie-tracker.com",
+                        "reason": "Site breakage"
+                    }
+                ],
+                "trackerCookie": "enabled",
+                "nonTrackerCookie": "disabled"
+            },
+            "exceptions": [
+                {
+                    "domain": "exception.local.site",
+                    "reason": "Site breakage"
+                }
+            ]
         }
     },
     "version": 1635943904459,


### PR DESCRIPTION
This re-instates the changes from: https://github.com/duckduckgo/privacy-reference-tests/compare/c17944584aa6b78c72675af04facd003ba2f97e4...97c951aeb53f5f1a1a22fde4b5d6f53868d9b13e which were lost in https://github.com/duckduckgo/privacy-reference-tests/pull/47

The extension has been pointing at these files which was one issue; we could choose to delete them and the corresponding code from the extension.

The more important change is block-third-party-tracking-cookies/config_reference.json which enables the feature for the extension given it got renamed.

https://app.asana.com/0/0/1202815437790493/f