### PR TITLE
Update CNAME domain matching test

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -73,14 +73,11 @@
                 "expectAction": "block"
             },
             {
-                "name": "random blocks cname tracker",
-                "siteURL": "https://randomsite123.com/",
+                "name": "first party blocks cname tracker",
+                "siteURL": "https://bad.cnames.test/",
                 "requestURL": "https://bad.cnames.test/something",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             },
             {
                 "name": "uncloacked tracker should contain original path and be checked against the ignore rules",


### PR DESCRIPTION
The `siteURL` used in this test should be a first party URL, so I've changed it to the same domain as the `requestURL`.

Tested on Apple + Android ✅