### PR TITLE
Remove Android exception for CNAME test

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -77,10 +77,7 @@
                 "siteURL": "https://randomsite123.com/",
                 "requestURL": "https://bad.cnames.test/something",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             },
             {
                 "name": "uncloacked tracker should contain original path and be checked against the ignore rules",


### PR DESCRIPTION
Cloaked CNAME detection in Android is now supported: https://github.com/duckduckgo/Android/pull/2216.