### PR TITLE
Add missing parameters to broken sites

### DIFF
--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -20,6 +20,10 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test"}
                 ],
+                "urlParameterRemoved": "0",
+                "consentManaged": "0",
+                "consentOptoutFailed": "0",
+                "consentSelftestFailed": "0",
                 "exceptPlatforms": []
             },
             {
@@ -40,6 +44,10 @@
                     {"name": "blockedTrackers", "value": ""},
                     {"name": "surrogates", "value": ""}
                 ],
+                "urlParameterRemoved": "0",
+                "consentManaged": "0",
+                "consentOptoutFailed": "0",
+                "consentSelftestFailed": "0",
                 "exceptPlatforms": []
             },
             {
@@ -68,6 +76,10 @@
                     {"name": "os", "value": "12"},
                     {"name": "gpc", "value": "true"}
                 ],
+                "urlParameterRemoved": "0",
+                "consentManaged": "0",
+                "consentOptoutFailed": "0",
+                "consentSelftestFailed": "0",
                 "exceptPlatforms": [
                     "web-extension",
                     "safari-extension"


### PR DESCRIPTION
https://app.asana.com/0/0/1203012116406182/f

This PR adds the missing parameters for autoconsent and urlParameterRemoved to the broken sites test