### PR TITLE
Fix tests

### DIFF
--- a/global-privacy-control/tests.json
+++ b/global-privacy-control/tests.json
@@ -117,10 +117,10 @@
                 "exceptPlatforms": []
             },
             {
-                "name": "API NOT injected - user opted out of GPC",
+                "name": "API injected but returns 'false' - user opted out of GPC",
                 "siteURL": "http://global-privacy-control.glitch.me",
                 "gpcUserSettingOn": false,
-                "expectGPCAPI": false,
+                "expectGPCAPI": true,
                 "expectGPCAPIValue": "false",
                 "exceptPlatforms": []
             }

--- a/global-privacy-control/tests.json
+++ b/global-privacy-control/tests.json
@@ -120,7 +120,7 @@
                 "name": "API NOT injected - user opted out of GPC",
                 "siteURL": "http://global-privacy-control.glitch.me",
                 "gpcUserSettingOn": false,
-                "expectGPCAPI": true,
+                "expectGPCAPI": false,
                 "expectGPCAPIValue": "false",
                 "exceptPlatforms": []
             }

--- a/tracker-radar-tests/TR-domain-matching/README.md
+++ b/tracker-radar-tests/TR-domain-matching/README.md
@@ -26,6 +26,7 @@ Test suite specific fields:
 #### Platform exceptions
 
 - "ports are ignored when matching rules" disabled for Apple platform ([bug report](https://app.asana.com/0/1163321984198618/1201849181617632/f))
+- "ports are ignored when matching rules" disabled for Android platform ([bug report](https://app.asana.com/0/488551667048375/1203150323419031/f))
 
 ### Privacy config allowlist
 

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -217,7 +217,8 @@
                 "exceptPlatforms": [
                     "web-extension",
                     "ios-browser",
-                    "web-extension-mv3"
+                    "web-extension-mv3",
+                    "android-browser"
                 ]
             }
         ]


### PR DESCRIPTION
https://app.asana.com/0/inbox/1125189844075764/1203114107513900/1203115935208287

This PR changes the value of `expectGPCAPI` which should be false rather than true when the setting is off. It also adds a exception for Android when "ports are ignored when matching rules" since when the test was introduced it was never tested on Android and only extensions and iOS (which both are ignoring the test).

