### PR TITLE
Re-enable port test for Android

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/README.md
+++ b/tracker-radar-tests/TR-domain-matching/README.md
@@ -26,7 +26,6 @@ Test suite specific fields:
 #### Platform exceptions
 
 - "ports are ignored when matching rules" disabled for Apple platform ([bug report](https://app.asana.com/0/1163321984198618/1201849181617632/f))
-- "ports are ignored when matching rules" disabled for Android platform ([bug report](https://app.asana.com/0/488551667048375/1203150323419031/f))
 
 ### Privacy config allowlist
 

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -217,8 +217,7 @@
                 "exceptPlatforms": [
                     "web-extension",
                     "ios-browser",
-                    "web-extension-mv3",
-                    "android-browser"
+                    "web-extension-mv3"
                 ]
             }
         ]


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1203158712142250/f

This PR re-enables the ports test on Android since we have now fixed the bug in https://github.com/duckduckgo/Android/pull/2402