### PR TITLE
Add desktop browsers to BSR specific test

### DIFF
--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -71,6 +71,8 @@
                 "exceptPlatforms": [
                     "web-extension",
                     "safari-extension"
+                    "macos-browser",
+                    "windows-browser"
                 ]
             }
         ]

--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -70,7 +70,7 @@
                 ],
                 "exceptPlatforms": [
                     "web-extension",
-                    "safari-extension"
+                    "safari-extension",
                     "macos-browser",
                     "windows-browser"
                 ]


### PR DESCRIPTION
According to the [specs](https://app.asana.com/0/1198207348643509/1200202563872939)  the model version should be only sent for mobile browsers but the [Native app specific fields](https://github.com/duckduckgo/privacy-reference-tests/blob/331144c5e20629fadd4d067e15a318451a9d7b4a/broken-site-reporting/tests.json#L67) test also expect the model version for macOS and Windows.

This PR adds macOS and Windows to the exceptPlatforms for the test that expects a model.