### PR TITLE
add gpcHeaderEnabledSites settings on GPC tests

### DIFF
--- a/global-privacy-control/config_reference.json
+++ b/global-privacy-control/config_reference.json
@@ -8,7 +8,12 @@
                     "domain": "washingtonpost.com",
                     "reason": "This is a domain where our iOS/Android apps inject the Sec-GPC request header"
                 }
-            ]
+            ],
+            "settings": {
+                "gpcHeaderEnabledSites": [
+                    "global-privacy-control.glitch.me"
+                ]
+            }
         }
     },
     "version": 1635943904459,

--- a/global-privacy-control/config_reference.json
+++ b/global-privacy-control/config_reference.json
@@ -11,7 +11,10 @@
             ],
             "settings": {
                 "gpcHeaderEnabledSites": [
-                    "global-privacy-control.glitch.me"
+                    "global-privacy-control.glitch.me",
+                    "washingtonpost.com",
+                    "globalprivacycontrol.org",
+                    "example.com"
                 ]
             }
         }


### PR DESCRIPTION
Task: https://app.asana.com/0/0/1203456821249393/f
This is necessary to comply to iOS/macOS GPC implementation