### PR TITLE
Add reference tests to ensure unsupported rule actions are ignored

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -240,6 +240,20 @@
                     "ios-browser",
                     "web-extension-mv3"
                 ]
+            },
+            {
+                "name": "unknown rule action ignored, default block",
+                "siteURL": "https://random.test/",
+                "requestURL": "https://tracker.test/unsupported-action",
+                "requestType": "script",
+                "expectAction": "block"
+            },
+            {
+                "name": "unknown rule action ignored, default ignore",
+                "siteURL": "https://random.test/",
+                "requestURL": "https://ignore.test/unsupported-action",
+                "requestType": "script",
+                "expectAction": "ignore"
             }
         ]
     },

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -63,6 +63,10 @@
                 {
                     "action": "ignore",
                     "rule": "tracker\\.test\\/breakage"
+                },
+                {
+                    "action": "unsupported-action",
+                    "rule": "tracker\\.test\\/unsupported-action"
                 }
             ]
         },
@@ -82,6 +86,10 @@
             "rules": [
                 {
                     "rule": "ignore\\.test\\/tracker"
+                },
+                {
+                    "action": "unsupported-action",
+                    "rule": "ignore\\.test/unsupported-action"
                 }
             ]
         },


### PR DESCRIPTION
With v4 of the block list, there can be rules with a custom rule
action (e.g. for the Click to Load feature). Platforms are expected to
ignore any such rules completely if the rule action isn't known to
them.