### PR TITLE
Remove Android exception for CNAME same entity test

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -134,8 +134,7 @@
                 "requestType": "script",
                 "expectAction": "ignore",
                 "exceptPlatforms": [
-                    "ios-browser",
-                    "android-browser"
+                    "ios-browser"
                 ]
             },
             {


### PR DESCRIPTION
https://app.asana.com/0/488551667048375/1203532296782616/f
This PR enables the CNAME same entity test on Android