### PR TITLE
CNAME leading . test

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -229,6 +229,13 @@
                 "expectAction": "block"
             },
             {
+                "name": "block a CNAME tracker path in ignore domain",
+                "siteURL": "https://random.test/",
+                "requestURL": "https://ignore.cloaked.test/tracker?abc=2",
+                "requestType": "script",
+                "expectAction": "block"
+            },
+            {
                 "name": "ports are ignored when matching rules",
                 "siteURL": "https://random.test/",
                 "requestURL": "https://bad.third-party.site:8080/ignore",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -180,7 +180,8 @@
     "cnames": {
         "bad.cnames.test": "cname.tracker.test",
         "fake-ignore.tracker.test": "tracker.ignore.test",
-        "domain.cloaked.test": "some.other.unknown.test"
+        "domain.cloaked.test": "some.other.unknown.test",
+        "ignore.cloaked.test": ".ignore.test"
     },
     "domains": {
         "bad.third-party.site": "Test Site for Tracker Blocking",


### PR DESCRIPTION
Captures an issue in privacy-grade (i.e. extension blocking) when CNAMEs have leading dots in their hostnames.

https://app.asana.com/0/0/1203759630885087/f