### PR TITLE
Enable type filtering reference test on Android

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -53,10 +53,7 @@
                 "siteURL": "https://ignore.test/",
                 "requestURL": "https://bad.third-party.site/",
                 "requestType": "script",
-                "expectAction": "block",
-                "exceptPlatforms": [
-                    "android-browser"
-                ]
+                "expectAction": "block"
             },
             {
                 "name": "notignore doesn't load tracker",


### PR DESCRIPTION
Asana task: https://app.asana.com/0/0/1203885070703634/f
This PR enables the "ignore image exception doesn't load tracker script" reference test on Android.