### PR TITLE
Add android exceptions for option tests

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -270,7 +270,9 @@
                 "siteURL": "https://ok-subdomain.also-site-that-tracks.com",
                 "requestURL": "https://sometimes-bad.third-party.site/option-blocking-only",
                 "requestType": "image",
-                "expectAction": "ignore"
+                "exceptPlatforms": [
+                    "android-browser"
+                ]
             },
             {
                 "name": "don't block tracker with site matching options domains but not types",
@@ -291,7 +293,10 @@
                 "siteURL": "https://example.com",
                 "requestURL": "https://sometimes-bad.third-party.site/option-blocking-only",
                 "requestType": "image",
-                "expectAction": "ignore"
+                "expectAction": "ignore",
+                "exceptPlatforms": [
+                    "android-browser"
+                ]
             },
             {
                 "name": "block default block tracker matching option domains",

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -270,6 +270,7 @@
                 "siteURL": "https://ok-subdomain.also-site-that-tracks.com",
                 "requestURL": "https://sometimes-bad.third-party.site/option-blocking-only",
                 "requestType": "image",
+                "expectAction": "ignore",
                 "exceptPlatforms": [
                     "android-browser"
                 ]


### PR DESCRIPTION
https://app.asana.com/0/0/1204192793460403/f
Option support is not yet implemented on Android, so I've added exceptions in the interim.