### PR TITLE
Added exceptions for windows smarter encryption tests

### DIFF
--- a/https-upgrades/README.md
+++ b/https-upgrades/README.md
@@ -78,4 +78,5 @@ thirdnegative.com
 ## Platform exceptions
 
 - Android, Windows, iOS and macOS don't support negative bloom filter because it's only needed for platforms where Smarter Encryption API is available
-- Android, Windows, iOS and macOS don't support updating subrequests because of WebView limitations (request can be cancelled, but not modified)
+- Android, iOS and macOS don't support updating subrequests because of WebView limitations (request can be cancelled, but not modified)
+- Windows don't support updating websocket subrequests because of WebView limitations (request can be cancelled, but not modified)

--- a/https-upgrades/README.md
+++ b/https-upgrades/README.md
@@ -77,5 +77,5 @@ thirdnegative.com
 
 ## Platform exceptions
 
-- Android, iOS and macOS don't support negative bloom filter because it's only needed for platforms where Smarter Encryption API is available
-- Android, iOS and macOS don't support updating subrequests because of WebView limitations (request can be cancelled, but not modified)
+- Android, Windows, iOS and macOS don't support negative bloom filter because it's only needed for platforms where Smarter Encryption API is available
+- Android, Windows, iOS and macOS don't support updating subrequests because of WebView limitations (request can be cancelled, but not modified)

--- a/https-upgrades/tests.json
+++ b/https-upgrades/tests.json
@@ -43,7 +43,8 @@
                 "expectURL": "http://negativetest.com/path/file.html?search=query&another=one#fragment",
                 "exceptPlatforms": [
                     "android-browser",
-                    "ios-browser"
+                    "ios-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -54,7 +55,8 @@
                 "expectURL": "https://s.secondnegative.com/path/file.html?search=query&another=one#fragment",
                 "exceptPlatforms": [
                     "android-browser",
-                    "ios-browser"
+                    "ios-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -147,7 +149,8 @@
                 "exceptPlatforms": [
                     "android-browser",
                     "ios-browser",
-                    "web-extension-mv3"
+                    "web-extension-mv3",
+                    "windows-browser"
                 ]
             },
             {


### PR DESCRIPTION
cc: @RendijsSmukulis @kdzwinel 

1. exclude negative bloom filter tests as we're not using negative bloom filters
2. exclude ws:// tests, as webview2 does not support ws:// interception

Picking up where @RendijsSmukulis's [PR](https://github.com/duckduckgo/privacy-reference-tests/pull/46) and extending it, since I'll need to update to the latest reference tests for option blocking and unkown rule action handling.