### PR TITLE
Reduce test noise when making PR

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,13 @@
 name: Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   linting:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test Implementations
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 jobs:
   extension:


### PR DESCRIPTION
This makes it so we just have the one set of tests run when making a PR (not the extra, redundant branch-push tests), and keeps the branch tests for pushes to `main`.

Previously, whenever opening a PR/pushing to a PR, two copies of each test would be generated, which made the CI listing pretty noisy.

This also disables the tests if the only change is a documentation one (i.e., `*.md`) as is standard.