### PR TITLE
Add some temp iOS exceptions for site reporting

### DIFF
--- a/broken-site-reporting/README.md
+++ b/broken-site-reporting/README.md
@@ -73,6 +73,10 @@ the reference tests is provided below:
     - `android-browser`, see https://app.asana.com/0/1163321984198618/1203936449485101/f
     - `ios-browser`, see https://app.asana.com/0/1163321984198618/1203944813756141
     - `safari-extension`, see https://app.asana.com/0/1201602070177732/1204307004967346
+- the following platforms don't yet encode etags in the expected manner
+  - `ios-browser`, see https://app.asana.com/0/0/1204852947979442/f
+- the following platforms don't yet send privacy configuration version information in reports:
+  - `ios-browser`, see https://app.asana.com/0/0/1204370595704517/f
 - truncation tests:
   - the following platforms do not currently implement the optional `noActionRequests`, `adAttributionRequests`, `ignoredByUserRequests`, or `ignoreRequests` truncatable parameters: `android-browser`, `ios-browser`, `macos-browser`, `safari-extension`, `windows-browser`
   - see https://app.asana.com/0/0/1204271046995906/f for more information about truncation and implementation requirements

--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -3,6 +3,28 @@
         "name": "Broken site report testing",
         "tests": [
             {
+                "name": "Simple test with a common set of fields (without config version)",
+                "siteURL": "https://example.test/",
+                "wasUpgraded": true,
+                "category": "content",
+                "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                "surrogates": ["surrogate.domain.test", "domain2.test"],
+                "atb": "v123-456g",
+                "blocklistVersion": "abc123",
+                "remoteConfigEtag": "abd142",
+                "remoteConfigVersion": "1234",
+                "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                "expectReportURLParams": [
+                    {"name": "category", "value": "content"},
+                    {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                    {"name": "upgradedHttps", "value": "true"},
+                    {"name": "tds", "value": "abc123"},
+                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                ],
+                "exceptPlatforms": []
+            },
+            {
                 "name": "Simple test with a common set of fields",
                 "siteURL": "https://example.test/",
                 "wasUpgraded": true,
@@ -24,7 +46,9 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
-                "exceptPlatforms": []
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
             },
             {
                 "name": "Test correct encoding of weak etags.",
@@ -48,7 +72,9 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
-                "exceptPlatforms": []
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
             },
             {
                 "name": "Test correct encoding of non-weak etags.",
@@ -72,7 +98,9 @@
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
-                "exceptPlatforms": []
+                "exceptPlatforms": [
+                    "ios-browser"
+                ]
             },
             {
                 "name": "Making sure that siteURL gets trimmed - path, query and fragment should be dropped",


### PR DESCRIPTION
iOS isn't sending privacy config version in reports currently. This adds exceptions to unblock the tests.

Also adds exceptions for the handling of etags until updated.

See https://app.asana.com/0/414709148257752/1204836191085934/f


- iOS passing (see https://app.asana.com/0/0/1204836191085934/1204857677987391/f)
- Android passing (see https://github.com/duckduckgo/Android/actions/runs/5321813596)
