### PR TITLE
Tests for the Harmful API protection

### DIFF
--- a/fingerprinting-protections/README.md
+++ b/fingerprinting-protections/README.md
@@ -27,7 +27,7 @@ Test suite specific fields:
 for $testSet in test.json
   loadReferenceConfig('config_reference.json')
 
-    for $test in $testSet
+    for $test in $testSet.tests
         if $test.exceptPlatforms includes 'current-platform'
             skip
 
@@ -39,7 +39,10 @@ for $testSet in test.json
 
         $value = $page.eval($test.property)
 
-        expect($value.toSting()).toBe($test.expectPropertyValue)
+        if ($value instanceof Promise)
+            $value = await $value
+
+        expect($value.toString()).toBe($test.expectPropertyValue)
 ```
 
 ## Platform exceptions

--- a/fingerprinting-protections/config_reference.json
+++ b/fingerprinting-protections/config_reference.json
@@ -47,6 +47,120 @@
                 }
             ],
             "state": "enabled"
+        },
+        "harmfulApis": {
+            "state": "enabled",
+            "exceptions": [
+                {
+                    "domain": "harmful-apis-exception.test",
+                    "reason": "Disable harmful API protections"
+                }
+            ],
+            "settings": {
+                "domains": [
+                    {
+                        "domain": "patched-harmful-api-settings.test",
+                        "patchSettings": [
+                            { "op": "replace", "path": "StorageManager/allowedQuotaValues", "value": [ 1337 ] },
+                            { "op": "replace", "path": "WindowPlacement/screenIsExtended", "value": true },
+                            { "op": "replace", "path": "WebSerial/state", "value": "disabled" }
+                        ]
+                    }
+                ],
+                "deviceOrientation": {
+                    "state": "enabled",
+                    "filterEvents": [
+                        "deviceorientation",
+                        "devicemotion"
+                    ]
+                },
+                "GenericSensor": {
+                    "state": "enabled",
+                    "filterPermissions": [
+                        "accelerometer",
+                        "ambient-light-sensor",
+                        "gyroscope",
+                        "magnetometer"
+                    ],
+                    "blockSensorStart": true
+                },
+                "UaClientHints": {
+                    "state": "enabled",
+                    "highEntropyValues": {
+                        "trimBrands": true,
+                        "model": "",
+                        "trimPlatformVersion": 2,
+                        "trimUaFullVersion": 1,
+                        "trimFullVersionList": 1
+                    }
+                },
+                "NetworkInformation": {
+                    "state": "enabled"
+                },
+                "getInstalledRelatedApps": {
+                    "state": "enabled",
+                    "returnValue": []
+                },
+                "FileSystemAccess": {
+                    "state": "enabled",
+                    "disableOpenFilePicker": true,
+                    "disableSaveFilePicker": true,
+                    "disableDirectoryPicker": true,
+                    "disableGetAsFileSystemHandle": true
+                },
+                "WindowPlacement": {
+                    "state": "enabled",
+                    "filterPermissions": [
+                        "window-placement",
+                        "window-management"
+                    ],
+                    "screenIsExtended": false
+                },
+                "WebBluetooth": {
+                    "state": "enabled",
+                    "filterPermissions": [
+                        "bluetooth"
+                    ],
+                    "filterEvents": ["availabilitychanged"],
+                    "blockGetAvailability": true,
+                    "blockRequestDevice": true
+                },
+                "WebUsb": {
+                    "state": "enabled"
+                },
+                "WebSerial": {
+                    "state": "enabled"
+                },
+                "WebHid": {
+                    "state": "enabled"
+                },
+                "WebMidi": {
+                    "state": "enabled",
+                    "filterPermissions": [
+                        "midi"
+                    ]
+                },
+                "IdleDetection": {
+                    "state": "enabled",
+                    "filterPermissions": [
+                        "idle-detection"
+                    ]
+                },
+                "WebNfc": {
+                    "state": "enabled",
+                    "disableNdefReader": true,
+                    "disableNdefMessage": true,
+                    "disableNdefRecord": true
+                },
+                "StorageManager": {
+                    "state": "enabled",
+                    "allowedQuotaValues": [
+                        1073741824,
+                        4294967296,
+                        9999999999
+                    ]
+                }
+            }
         }
     },
     "version": 1635943904459,

--- a/fingerprinting-protections/config_reference.json
+++ b/fingerprinting-protections/config_reference.json
@@ -105,7 +105,7 @@
                 },
                 "getInstalledRelatedApps": {
                     "state": "enabled",
-                    "returnValue": []
+                    "returnValue": ["overridden-return-value"]
                 },
                 "FileSystemAccess": {
                     "state": "enabled",

--- a/fingerprinting-protections/config_reference.json
+++ b/fingerprinting-protections/config_reference.json
@@ -64,6 +64,7 @@
                             { "op": "replace", "path": "/deviceOrientation/filterEvents", "value": [ "deviceorientation" ] },
                             { "op": "replace", "path": "/StorageManager/allowedQuotaValues", "value": [ 1337 ] },
                             { "op": "replace", "path": "/WindowPlacement/screenIsExtended", "value": true },
+                            { "op": "replace", "path": "/UaClientHints/highEntropyValues/trimPlatformVersion", "value": 1 },
                             { "op": "replace", "path": "/WebSerial/state", "value": "disabled" }
                         ]
                     }
@@ -89,10 +90,14 @@
                     "state": "enabled",
                     "highEntropyValues": {
                         "trimBrands": true,
-                        "model": "",
+                        "model": "overridden-model",
                         "trimPlatformVersion": 2,
                         "trimUaFullVersion": 1,
-                        "trimFullVersionList": 1
+                        "trimFullVersionList": 1,
+                        "architecture": "overridden-architecture",
+                        "bitness": 16,
+                        "platform": "overridden-platform",
+                        "mobile": true
                     }
                 },
                 "NetworkInformation": {

--- a/fingerprinting-protections/config_reference.json
+++ b/fingerprinting-protections/config_reference.json
@@ -161,9 +161,7 @@
                 "StorageManager": {
                     "state": "enabled",
                     "allowedQuotaValues": [
-                        1073741824,
-                        4294967296,
-                        9999999999
+                        1, 1337, 31337
                     ]
                 }
             }

--- a/fingerprinting-protections/config_reference.json
+++ b/fingerprinting-protections/config_reference.json
@@ -61,9 +61,10 @@
                     {
                         "domain": "patched-harmful-api-settings.test",
                         "patchSettings": [
-                            { "op": "replace", "path": "StorageManager/allowedQuotaValues", "value": [ 1337 ] },
-                            { "op": "replace", "path": "WindowPlacement/screenIsExtended", "value": true },
-                            { "op": "replace", "path": "WebSerial/state", "value": "disabled" }
+                            { "op": "replace", "path": "/deviceOrientation/filterEvents", "value": [ "deviceorientation" ] },
+                            { "op": "replace", "path": "/StorageManager/allowedQuotaValues", "value": [ 1337 ] },
+                            { "op": "replace", "path": "/WindowPlacement/screenIsExtended", "value": true },
+                            { "op": "replace", "path": "/WebSerial/state", "value": "disabled" }
                         ]
                     }
                 ],

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -127,6 +127,10 @@ function init(window) {
             }
         }
     }
+
+    if (typeof window.screen.isExtended === 'undefined') {
+        Object.defineProperty(window.Screen.prototype, 'isExtended', { get: () => true, configurable: true });
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -46,6 +46,56 @@ function init(window) {
     if (!window.Gyroscope) window.Gyroscope = ConcreteSensorMock;
     if (!window.LinearAccelerationSensor) window.LinearAccelerationSensor = ConcreteSensorMock;
     if (!window.RelativeOrientationSensor) window.RelativeOrientationSensor = ConcreteSensorMock;
+
+    if (!window.NavigatorUAData) {
+        window.NavigatorUAData = class {
+            async getHighEntropyValues() {
+                return { platform: 'Win32' };
+            }
+        }
+        window.navigator.userAgentData = new window.NavigatorUAData();
+    }
+
+    // freeze the base return value for getHighEntropyValues to not depend on the actual browser
+    window.NavigatorUAData.prototype.getHighEntropyValues = function() {
+        return Promise.resolve({
+            "architecture": "arm",
+            "bitness": "64",
+            "brands": [
+                {
+                    "brand": "Not.A/Brand",
+                    "version": "8"
+                },
+                {
+                    "brand": "Chromium",
+                    "version": "114"
+                },
+                {
+                    "brand": "Google Chrome",
+                    "version": "114"
+                }
+            ],
+            "fullVersionList": [
+                {
+                    "brand": "Not.A/Brand",
+                    "version": "8.0.0.0"
+                },
+                {
+                    "brand": "Chromium",
+                    "version": "114.1.5735.198"
+                },
+                {
+                    "brand": "Google Chrome",
+                    "version": "114.1.5735.198"
+                }
+            ],
+            "mobile": false,
+            "model": "some-real-model",
+            "platform": "macOS",
+            "platformVersion": "13.4.1",
+            "uaFullVersion": "114.0.5735.198"
+        });
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -6,7 +6,7 @@ function init(window) {
     Object.defineProperty(BatteryManager.prototype, 'charging', { get: () => false, configurable: true });
     Object.defineProperty(BatteryManager.prototype, 'chargingTime', { get: () => 12345, configurable: true });
     Object.defineProperty(BatteryManager.prototype, 'dischargingTime', { get: () => 12345, configurable: true });
-    
+
     window.BatteryManager = BatteryManager;
     window.navigator.getBattery = () => Promise.resolve(new BatteryManager());
 
@@ -25,6 +25,14 @@ function init(window) {
             callback(0, 9999999999)
         }
     };
+
+    window.DeviceOrientationEvent = window.Event; // we only need the constructor in tests
+    window.DeviceMotionEvent = window.Event; // we only need the constructor in tests
+    window.Permissions = class {
+        query() {
+            return Promise.resolve({ state: 'granted' });
+        }
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -143,6 +143,15 @@ function init(window) {
         }
         window.navigator.bluetooth = new window.Bluetooth();
     }
+
+    if (!window.navigator.usb) {
+        window.USB = class {
+            requestDevice() {
+                return Promise.resolve('mocked-USB-requestDevice-result');
+            }
+        }
+        window.navigator.usb = new window.USB();
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -174,6 +174,12 @@ function init(window) {
     if (!window.navigator.requestMIDIAccess) {
         Object.getPrototypeOf(window.navigator).requestMIDIAccess = () => Promise.resolve('mocked-requestMIDIAccess-result');
     }
+
+    if (!window.IdleDetector) {
+        window.IdleDetector = class {
+            start() {}
+        }
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -33,6 +33,19 @@ function init(window) {
             return Promise.resolve({ state: 'granted' });
         }
     }
+    window.navigator.permissions = new window.Permissions();
+
+    class SensorMock extends EventTarget {
+        start() {}
+    }
+    if (!window.Sensor) window.Sensor = SensorMock;
+    class ConcreteSensorMock extends window.Sensor {}
+    if (!window.AbsoluteOrientationSensor) window.AbsoluteOrientationSensor = ConcreteSensorMock;
+    if (!window.Accelerometer) window.Accelerometer = ConcreteSensorMock;
+    if (!window.GravitySensor) window.GravitySensor = ConcreteSensorMock;
+    if (!window.Gyroscope) window.Gyroscope = ConcreteSensorMock;
+    if (!window.LinearAccelerationSensor) window.LinearAccelerationSensor = ConcreteSensorMock;
+    if (!window.RelativeOrientationSensor) window.RelativeOrientationSensor = ConcreteSensorMock;
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -152,6 +152,15 @@ function init(window) {
         }
         window.navigator.usb = new window.USB();
     }
+
+    if (!window.navigator.serial) {
+        window.Serial = class {
+            requestPort() {
+                return Promise.resolve('mocked-Serial-requestPort-result');
+            }
+        }
+        window.navigator.serial = new window.Serial();
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -180,6 +180,18 @@ function init(window) {
             start() {}
         }
     }
+
+    if (!window.NDEFReader) {
+        window.NDEFReader = class {}
+    }
+
+    if (!window.NDEFMessage) {
+        window.NDEFMessage = class {}
+    }
+
+    if (!window.NDEFRecord) {
+        window.NDEFRecord = class {}
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -96,6 +96,37 @@ function init(window) {
             "uaFullVersion": "114.0.5735.198"
         });
     }
+
+    if (!window.navigator.connection) {
+        Object.getPrototypeOf(window.navigator).connection = {
+            rtt: 12345,
+            downlink: 12345,
+            effectiveType: '4g'
+        };
+    }
+
+    if (!window.navigator.getInstalledRelatedApps) {
+        Object.getPrototypeOf(window.navigator).getInstalledRelatedApps = async function() {
+            return ['some-returned-app'];
+        }
+    }
+
+    if (!window.showOpenFilePicker) {
+        window.showOpenFilePicker = () => 'mocked-showOpenFilePicker-result';
+    }
+    if (!window.showSaveFilePicker) {
+        window.showSaveFilePicker = () => 'mocked-showSaveFilePicker-result';
+    }
+    if (!window.showDirectoryPicker) {
+        window.showDirectoryPicker = () => 'mocked-showDirectoryPicker-result';
+    }
+    if (!window.DataTransferItem) {
+        window.DataTransferItem = class {
+            getAsFileSystemHandle() {
+                return 'mocked-DataTransferItem-getAsFileSystemHandle-result';
+            }
+        }
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -156,10 +156,23 @@ function init(window) {
     if (!window.navigator.serial) {
         window.Serial = class {
             requestPort() {
-                return Promise.resolve('mocked-Serial-requestPort-result');
+                return Promise.resolve(['mocked-Serial-requestPort-result']);
             }
         }
         window.navigator.serial = new window.Serial();
+    }
+
+    if (!window.navigator.hid) {
+        window.HID = class {
+            requestDevice() {
+                return Promise.resolve(['mocked-HID-requestDevice-result']);
+            }
+        }
+        window.navigator.hid = new window.HID();
+    }
+
+    if (!window.navigator.requestMIDIAccess) {
+        Object.getPrototypeOf(window.navigator).requestMIDIAccess = () => Promise.resolve('mocked-requestMIDIAccess-result');
     }
 }
 

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -192,6 +192,18 @@ function init(window) {
     if (!window.NDEFRecord) {
         window.NDEFRecord = class {}
     }
+
+    if (!window.navigator.storage) {
+        window.StorageManager = class {
+            async estimate() {
+                return {
+                    quota: 12345,
+                    usage: 111
+                };
+            }
+        }
+        Object.getPrototypeOf(window.navigator).storage = new window.StorageManager();
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/init.js
+++ b/fingerprinting-protections/init.js
@@ -131,6 +131,18 @@ function init(window) {
     if (typeof window.screen.isExtended === 'undefined') {
         Object.defineProperty(window.Screen.prototype, 'isExtended', { get: () => true, configurable: true });
     }
+
+    if (!window.navigator.bluetooth) {
+        window.Bluetooth = class {
+            getAvailability() {
+                return Promise.resolve(true);
+            }
+            requestDevice() {
+                return Promise.resolve('mocked-Bluetooth-requestDevice-result');
+            }
+        }
+        window.navigator.bluetooth = new window.Bluetooth();
+    }
 }
 
 if (typeof module !== 'undefined' && module.exports) {

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -591,7 +591,49 @@
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "Window Placement API - window-placement permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'window-placement' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "Window Placement API - window-management permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'window-management' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "Window Placement API - Screen.prototype.isExtended",
+                "siteURL": "https://example.com/",
+                "property": "window.screen.isExtended",
+                "expectPropertyValue": "false",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "Window Placement API - Screen.prototype.isExtended site exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "window.screen.isExtended",
+                "expectPropertyValue": "true",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "Window Placement API - Screen.prototype.isExtended domain override",
+                "siteURL": "https://patched-harmful-api-settings.test/",
+                "property": "window.screen.isExtended",
+                "expectPropertyValue": "true",
+                "exceptPlatforms": [
+                ]
             }
+
         ]
     }
 }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -273,7 +273,12 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('deviceorientation', () => { firedEvent = 'deviceorientation' }); window.dispatchEvent(new DeviceOrientationEvent('deviceorientation')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "none",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -282,7 +287,12 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('deviceorientation', () => { firedEvent = 'deviceorientation' }); window.dispatchEvent(new DeviceOrientationEvent('deviceorientation')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "deviceorientation",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -291,7 +301,12 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "none",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -300,7 +315,12 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "devicemotion",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -309,7 +329,12 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "devicemotion",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -319,7 +344,12 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -328,7 +358,12 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -337,7 +372,12 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -346,7 +386,12 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -355,7 +400,12 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -364,7 +414,12 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -374,7 +429,12 @@
                 "property": "navigator.permissions.query({ name: 'accelerometer' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -383,7 +443,12 @@
                 "property": "navigator.permissions.query({ name: 'gyroscope' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -392,7 +457,12 @@
                 "property": "navigator.permissions.query({ name: 'magnetometer' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -401,7 +471,12 @@
                 "property": "navigator.permissions.query({ name: 'accelerometer' }).then(result => result.state)",
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -410,7 +485,12 @@
                 "property": "navigator.permissions.query({ name: 'gyroscope' }).then(result => result.state)",
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -419,7 +499,12 @@
                 "property": "navigator.permissions.query({ name: 'magnetometer' }).then(result => result.state)",
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -428,7 +513,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['model']).then(result => result.model)",
                 "expectPropertyValue": "overridden-model",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -437,7 +527,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['model']).then(result => result.model)",
                 "expectPropertyValue": "some-real-model",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -446,7 +541,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
                 "expectPropertyValue": "13.4.0",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -455,7 +555,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
                 "expectPropertyValue": "13.4.1",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -464,7 +569,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
                 "expectPropertyValue": "13.0.0",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -473,7 +583,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['uaFullVersion']).then(result => result.uaFullVersion)",
                 "expectPropertyValue": "114.0.0.0",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -482,7 +597,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['fullVersionList']).then(result => `${result.fullVersionList[1].version},${result.fullVersionList[2].version}`)",
                 "expectPropertyValue": "114.0.0.0,114.0.0.0",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -491,7 +611,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['architecture']).then(result => result.architecture)",
                 "expectPropertyValue": "overridden-architecture",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -500,7 +625,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['bitness']).then(result => result.bitness)",
                 "expectPropertyValue": "16",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -509,7 +639,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platform']).then(result => result.platform)",
                 "expectPropertyValue": "overridden-platform",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -518,7 +653,12 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['mobile']).then(result => result.mobile)",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -528,7 +668,12 @@
                 "property": "typeof navigator.connection",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -537,7 +682,12 @@
                 "property": "typeof navigator.connection",
                 "expectPropertyValue": "object",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -547,7 +697,12 @@
                 "property": "navigator.getInstalledRelatedApps().then(apps => apps.join(','))",
                 "expectPropertyValue": "overridden-return-value",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -556,7 +711,12 @@
                 "property": "navigator.getInstalledRelatedApps().then(apps => apps.join(','))",
                 "expectPropertyValue": "some-returned-app",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -566,7 +726,12 @@
                 "property": "typeof window.showOpenFilePicker",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -575,7 +740,12 @@
                 "property": "typeof window.showSaveFilePicker",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -584,7 +754,12 @@
                 "property": "typeof window.showDirectoryPicker",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -593,7 +768,12 @@
                 "property": "typeof window.showOpenFilePicker",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -602,7 +782,12 @@
                 "property": "typeof window.showSaveFilePicker",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -611,7 +796,12 @@
                 "property": "typeof window.showDirectoryPicker",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -620,7 +810,12 @@
                 "property": "typeof DataTransferItem.prototype.getAsFileSystemHandle",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -629,7 +824,12 @@
                 "property": "typeof DataTransferItem.prototype.getAsFileSystemHandle",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -639,7 +839,12 @@
                 "property": "navigator.permissions.query({ name: 'window-placement' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -648,7 +853,12 @@
                 "property": "navigator.permissions.query({ name: 'window-management' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -657,7 +867,12 @@
                 "property": "window.screen.isExtended",
                 "expectPropertyValue": "false",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -666,7 +881,12 @@
                 "property": "window.screen.isExtended",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -675,7 +895,12 @@
                 "property": "window.screen.isExtended",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -685,7 +910,12 @@
                 "property": "navigator.bluetooth.getAvailability()",
                 "expectPropertyValue": "false",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -694,7 +924,12 @@
                 "property": "navigator.bluetooth.getAvailability()",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -703,7 +938,12 @@
                 "property": "navigator.bluetooth.requestDevice({acceptAllDevices: true}).catch(e => e.message)",
                 "expectPropertyValue": "Bluetooth permission has been blocked.",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -712,7 +952,12 @@
                 "property": "navigator.bluetooth.requestDevice({acceptAllDevices: true})",
                 "expectPropertyValue": "mocked-Bluetooth-requestDevice-result",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -722,7 +967,12 @@
                 "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
                 "expectPropertyValue": "No device selected.",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -731,7 +981,12 @@
                 "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
                 "expectPropertyValue": "mocked-USB-requestDevice-result",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -741,7 +996,12 @@
                 "property": "navigator.serial.requestPort().catch(e => e.message)",
                 "expectPropertyValue": "No port selected.",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -750,7 +1010,12 @@
                 "property": "navigator.serial.requestPort().catch(e => e.message)",
                 "expectPropertyValue": "mocked-Serial-requestPort-result",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -759,7 +1024,12 @@
                 "property": "navigator.serial.requestPort().catch(e => e.message)",
                 "expectPropertyValue": "mocked-Serial-requestPort-result",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -769,7 +1039,12 @@
                 "property": "navigator.hid.requestDevice({ filters: [] }).then(result => result.join(','))",
                 "expectPropertyValue": "",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -778,7 +1053,12 @@
                 "property": "navigator.hid.requestDevice({ filters: [] }).then(result => result.join(','))",
                 "expectPropertyValue": "mocked-HID-requestDevice-result",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -788,7 +1068,12 @@
                 "property": "navigator.requestMIDIAccess().catch(err => err.message)",
                 "expectPropertyValue": "Permission is denied.",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -797,7 +1082,12 @@
                 "property": "navigator.requestMIDIAccess().catch(err => err.message)",
                 "expectPropertyValue": "mocked-requestMIDIAccess-result",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -806,7 +1096,12 @@
                 "property": "navigator.permissions.query({ name: 'midi' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -816,7 +1111,12 @@
                 "property": "typeof window.IdleDetector",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -825,7 +1125,12 @@
                 "property": "typeof window.IdleDetector",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -834,7 +1139,12 @@
                 "property": "navigator.permissions.query({ name: 'idle-detection' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -844,7 +1154,12 @@
                 "property": "typeof window.NDEFReader",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -853,7 +1168,12 @@
                 "property": "typeof window.NDEFReader",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -862,7 +1182,12 @@
                 "property": "typeof window.NDEFMessage",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -871,7 +1196,12 @@
                 "property": "typeof window.NDEFMessage",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -880,7 +1210,12 @@
                 "property": "typeof window.NDEFRecord",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
             {
@@ -889,7 +1224,12 @@
                 "property": "typeof window.NDEFRecord",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             },
 
@@ -899,7 +1239,12 @@
                 "property": "navigator.storage.estimate().then(r => r.quota).catch(e => e.message)",
                 "expectPropertyValue": "1337",
                 "exceptPlatforms": [
-                    "web-extension"
+                    "web-extension",
+                    "safari-extension",
+                    "ios-browser",
+                    "android-browser",
+                    "macos-browser",
+                    "windows-browser"
                 ]
             }
         ]

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -653,7 +653,7 @@
             {
                 "name": "WebBluetooth API requestDevice()",
                 "siteURL": "https://example.com/",
-                "property": "navigator.bluetooth.requestDevice().catch(e => e.message)",
+                "property": "navigator.bluetooth.requestDevice({acceptAllDevices: true}).catch(e => e.message)",
                 "expectPropertyValue": "Bluetooth permission has been blocked.",
                 "exceptPlatforms": [
                 ]
@@ -661,11 +661,30 @@
             {
                 "name": "WebBluetooth API requestDevice() exception",
                 "siteURL": "https://harmful-apis-exception.test/",
-                "property": "navigator.bluetooth.requestDevice()",
+                "property": "navigator.bluetooth.requestDevice({acceptAllDevices: true})",
                 "expectPropertyValue": "mocked-Bluetooth-requestDevice-result",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "WebUSB API",
+                "siteURL": "https://example.com/",
+                "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
+                "expectPropertyValue": "No device selected.",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebUSB API exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
+                "expectPropertyValue": "mocked-USB-requestDevice-result",
+                "exceptPlatforms": [
+                ]
             }
+
+
         ]
     }
 }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -774,6 +774,55 @@
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "WebNFC API NDEFReader",
+                "siteURL": "https://example.test",
+                "property": "typeof window.NDEFReader",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebNFC API NDEFReader exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "typeof window.NDEFReader",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebNFC API NDEFMessage",
+                "siteURL": "https://example.test",
+                "property": "typeof window.NDEFMessage",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebNFC API NDEFMessage exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "typeof window.NDEFMessage",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebNFC API NDEFRecord",
+                "siteURL": "https://example.test",
+                "property": "typeof window.NDEFRecord",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebNFC API NDEFRecord exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "typeof window.NDEFRecord",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -404,6 +404,94 @@
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
                 ]
+            },
+            {
+                "name": "UA hints model",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['model']).then(result => result.model)",
+                "expectPropertyValue": "overridden-model",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints model exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['model']).then(result => result.model)",
+                "expectPropertyValue": "some-real-model",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints platformVersion",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
+                "expectPropertyValue": "13.4.0",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints platformVersion exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
+                "expectPropertyValue": "13.4.1",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints platformVersion override",
+                "siteURL": "https://patched-harmful-api-settings.test/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
+                "expectPropertyValue": "13.0.0",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints uaFullVersion",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['uaFullVersion']).then(result => result.uaFullVersion)",
+                "expectPropertyValue": "114.0.0.0",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints fullVersionList",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['fullVersionList']).then(result => `${result.fullVersionList[1].version},${result.fullVersionList[2].version}`)",
+                "expectPropertyValue": "114.0.0.0,114.0.0.0",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints architecture",
+                "siteURL": "https://example.test/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['architecture']).then(result => result.architecture)",
+                "expectPropertyValue": "overridden-architecture",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints bitness",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['bitness']).then(result => result.bitness)",
+                "expectPropertyValue": "16",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints platform",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['platform']).then(result => result.platform)",
+                "expectPropertyValue": "overridden-platform",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "UA hints mobile",
+                "siteURL": "https://example.com/",
+                "property": "navigator.userAgentData.getHighEntropyValues(['mobile']).then(result => result.mobile)",
+                "expectPropertyValue": "true",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -707,6 +707,48 @@
                 "expectPropertyValue": "mocked-Serial-requestPort-result",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "WebHID API requestDevice",
+                "siteURL": "https://example.com/",
+                "property": "navigator.hid.requestDevice({ filters: [] }).then(result => result.join(','))",
+                "expectPropertyValue": "",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebHID API requestDevice exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "navigator.hid.requestDevice({ filters: [] }).then(result => result.join(','))",
+                "expectPropertyValue": "mocked-HID-requestDevice-result",
+                "exceptPlatforms": [
+                ]
+            },
+
+            {
+                "name": "WebMIDI API navigator.requestMIDIAccess()",
+                "siteURL": "https://example.test",
+                "property": "navigator.requestMIDIAccess().catch(err => err.message)",
+                "expectPropertyValue": "Permission is denied.",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebMIDI API navigator.requestMIDIAccess() exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "navigator.requestMIDIAccess().catch(err => err.message)",
+                "expectPropertyValue": "mocked-requestMIDIAccess-result",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebMIDI API midi permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'midi' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -632,8 +632,40 @@
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
                 ]
-            }
+            },
 
+            {
+                "name": "WebBluetooth API getAvailability()",
+                "siteURL": "https://example.com/",
+                "property": "navigator.bluetooth.getAvailability()",
+                "expectPropertyValue": "false",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebBluetooth API getAvailability() exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.bluetooth.getAvailability()",
+                "expectPropertyValue": "true",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebBluetooth API requestDevice()",
+                "siteURL": "https://example.com/",
+                "property": "navigator.bluetooth.requestDevice().catch(e => e.message)",
+                "expectPropertyValue": "Bluetooth permission has been blocked.",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebBluetooth API requestDevice() exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.bluetooth.requestDevice()",
+                "expectPropertyValue": "mocked-Bluetooth-requestDevice-result",
+                "exceptPlatforms": [
+                ]
+            }
         ]
     }
 }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -823,6 +823,15 @@
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "StarageManager quota estimation API",
+                "siteURL": "https://example.com/",
+                "property": "navigator.storage.estimate().then(r => r.quota).catch(e => e.message)",
+                "expectPropertyValue": "1337",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -749,6 +749,31 @@
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "IdleDetection API IdleDetector",
+                "siteURL": "https://example.test",
+                "property": "typeof window.IdleDetector",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "IdleDetection API IdleDetector exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "typeof window.IdleDetector",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "IdleDetection API idle-detection permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'idle-detection' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -262,5 +262,51 @@
                    ]
             }
         ]
+    },
+    "harmfulAPIs": {
+        "name": "Harmful APIs",
+        "desc": "Various web APIs should be modified or disabled to prevent leaking private data",
+        "tests": [
+            {
+                "name": "deviceorientation event",
+                "siteURL": "https://example.com/",
+                "property": "firedEvent='none',(t=()=>{window.addEventListener('deviceorientation', () => { firedEvent = 'deviceorientation' }); window.dispatchEvent(new DeviceOrientationEvent('deviceorientation')); return 333}),t(),firedEvent",
+                "expectPropertyValue": "none",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "deviceorientation event exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "firedEvent='none',(t=()=>{window.addEventListener('deviceorientation', () => { firedEvent = 'deviceorientation' }); window.dispatchEvent(new DeviceOrientationEvent('deviceorientation')); return 333}),t(),firedEvent",
+                "expectPropertyValue": "deviceorientation",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "devicemotion event",
+                "siteURL": "https://example.com/",
+                "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
+                "expectPropertyValue": "none",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "devicemotion event exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
+                "expectPropertyValue": "devicemotion",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "devicemotion event patch mitigation",
+                "siteURL": "https://patched-harmful-api-settings.test/",
+                "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
+                "expectPropertyValue": "devicemotion",
+                "exceptPlatforms": [
+                ]
+            }
+        ]
     }
 }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -273,6 +273,7 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('deviceorientation', () => { firedEvent = 'deviceorientation' }); window.dispatchEvent(new DeviceOrientationEvent('deviceorientation')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "none",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -281,6 +282,7 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('deviceorientation', () => { firedEvent = 'deviceorientation' }); window.dispatchEvent(new DeviceOrientationEvent('deviceorientation')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "deviceorientation",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -289,6 +291,7 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "none",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -297,6 +300,7 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "devicemotion",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -305,6 +309,7 @@
                 "property": "firedEvent='none',(t=()=>{window.addEventListener('devicemotion', () => { firedEvent = 'devicemotion' }); window.dispatchEvent(new DeviceMotionEvent('devicemotion')); return 333}),t(),firedEvent",
                 "expectPropertyValue": "devicemotion",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -314,6 +319,7 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -322,6 +328,7 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -330,6 +337,7 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -338,6 +346,7 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -346,6 +355,7 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -354,6 +364,7 @@
                 "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
                 "expectPropertyValue": "threw",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -363,6 +374,7 @@
                 "property": "navigator.permissions.query({ name: 'accelerometer' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -371,6 +383,7 @@
                 "property": "navigator.permissions.query({ name: 'gyroscope' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -379,6 +392,7 @@
                 "property": "navigator.permissions.query({ name: 'magnetometer' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -387,6 +401,7 @@
                 "property": "navigator.permissions.query({ name: 'accelerometer' }).then(result => result.state)",
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -395,6 +410,7 @@
                 "property": "navigator.permissions.query({ name: 'gyroscope' }).then(result => result.state)",
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -403,6 +419,7 @@
                 "property": "navigator.permissions.query({ name: 'magnetometer' }).then(result => result.state)",
                 "expectPropertyValue": "granted",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -411,6 +428,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['model']).then(result => result.model)",
                 "expectPropertyValue": "overridden-model",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -419,6 +437,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['model']).then(result => result.model)",
                 "expectPropertyValue": "some-real-model",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -427,6 +446,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
                 "expectPropertyValue": "13.4.0",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -435,6 +455,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
                 "expectPropertyValue": "13.4.1",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -443,6 +464,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platformVersion']).then(result => result.platformVersion)",
                 "expectPropertyValue": "13.0.0",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -451,6 +473,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['uaFullVersion']).then(result => result.uaFullVersion)",
                 "expectPropertyValue": "114.0.0.0",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -459,6 +482,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['fullVersionList']).then(result => `${result.fullVersionList[1].version},${result.fullVersionList[2].version}`)",
                 "expectPropertyValue": "114.0.0.0,114.0.0.0",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -467,6 +491,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['architecture']).then(result => result.architecture)",
                 "expectPropertyValue": "overridden-architecture",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -475,6 +500,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['bitness']).then(result => result.bitness)",
                 "expectPropertyValue": "16",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -483,6 +509,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['platform']).then(result => result.platform)",
                 "expectPropertyValue": "overridden-platform",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -491,6 +518,7 @@
                 "property": "navigator.userAgentData.getHighEntropyValues(['mobile']).then(result => result.mobile)",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -500,6 +528,7 @@
                 "property": "typeof navigator.connection",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -508,6 +537,7 @@
                 "property": "typeof navigator.connection",
                 "expectPropertyValue": "object",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -517,6 +547,7 @@
                 "property": "navigator.getInstalledRelatedApps().then(apps => apps.join(','))",
                 "expectPropertyValue": "overridden-return-value",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -525,6 +556,7 @@
                 "property": "navigator.getInstalledRelatedApps().then(apps => apps.join(','))",
                 "expectPropertyValue": "some-returned-app",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -534,6 +566,7 @@
                 "property": "typeof window.showOpenFilePicker",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -542,6 +575,7 @@
                 "property": "typeof window.showSaveFilePicker",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -550,6 +584,7 @@
                 "property": "typeof window.showDirectoryPicker",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -558,6 +593,7 @@
                 "property": "typeof window.showOpenFilePicker",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -566,6 +602,7 @@
                 "property": "typeof window.showSaveFilePicker",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -574,6 +611,7 @@
                 "property": "typeof window.showDirectoryPicker",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -582,6 +620,7 @@
                 "property": "typeof DataTransferItem.prototype.getAsFileSystemHandle",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -590,6 +629,7 @@
                 "property": "typeof DataTransferItem.prototype.getAsFileSystemHandle",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -599,6 +639,7 @@
                 "property": "navigator.permissions.query({ name: 'window-placement' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -607,6 +648,7 @@
                 "property": "navigator.permissions.query({ name: 'window-management' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -615,6 +657,7 @@
                 "property": "window.screen.isExtended",
                 "expectPropertyValue": "false",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -623,6 +666,7 @@
                 "property": "window.screen.isExtended",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -631,6 +675,7 @@
                 "property": "window.screen.isExtended",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -640,6 +685,7 @@
                 "property": "navigator.bluetooth.getAvailability()",
                 "expectPropertyValue": "false",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -648,6 +694,7 @@
                 "property": "navigator.bluetooth.getAvailability()",
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -656,6 +703,7 @@
                 "property": "navigator.bluetooth.requestDevice({acceptAllDevices: true}).catch(e => e.message)",
                 "expectPropertyValue": "Bluetooth permission has been blocked.",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -664,6 +712,7 @@
                 "property": "navigator.bluetooth.requestDevice({acceptAllDevices: true})",
                 "expectPropertyValue": "mocked-Bluetooth-requestDevice-result",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -673,6 +722,7 @@
                 "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
                 "expectPropertyValue": "No device selected.",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -681,6 +731,7 @@
                 "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
                 "expectPropertyValue": "mocked-USB-requestDevice-result",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -690,6 +741,7 @@
                 "property": "navigator.serial.requestPort().catch(e => e.message)",
                 "expectPropertyValue": "No port selected.",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -698,6 +750,7 @@
                 "property": "navigator.serial.requestPort().catch(e => e.message)",
                 "expectPropertyValue": "mocked-Serial-requestPort-result",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -706,6 +759,7 @@
                 "property": "navigator.serial.requestPort().catch(e => e.message)",
                 "expectPropertyValue": "mocked-Serial-requestPort-result",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -715,6 +769,7 @@
                 "property": "navigator.hid.requestDevice({ filters: [] }).then(result => result.join(','))",
                 "expectPropertyValue": "",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -723,6 +778,7 @@
                 "property": "navigator.hid.requestDevice({ filters: [] }).then(result => result.join(','))",
                 "expectPropertyValue": "mocked-HID-requestDevice-result",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -732,6 +788,7 @@
                 "property": "navigator.requestMIDIAccess().catch(err => err.message)",
                 "expectPropertyValue": "Permission is denied.",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -740,6 +797,7 @@
                 "property": "navigator.requestMIDIAccess().catch(err => err.message)",
                 "expectPropertyValue": "mocked-requestMIDIAccess-result",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -748,6 +806,7 @@
                 "property": "navigator.permissions.query({ name: 'midi' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -757,6 +816,7 @@
                 "property": "typeof window.IdleDetector",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -765,6 +825,7 @@
                 "property": "typeof window.IdleDetector",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -773,6 +834,7 @@
                 "property": "navigator.permissions.query({ name: 'idle-detection' }).then(result => result.state)",
                 "expectPropertyValue": "denied",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -782,6 +844,7 @@
                 "property": "typeof window.NDEFReader",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -790,6 +853,7 @@
                 "property": "typeof window.NDEFReader",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -798,6 +862,7 @@
                 "property": "typeof window.NDEFMessage",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -806,6 +871,7 @@
                 "property": "typeof window.NDEFMessage",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -814,6 +880,7 @@
                 "property": "typeof window.NDEFRecord",
                 "expectPropertyValue": "undefined",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
             {
@@ -822,6 +889,7 @@
                 "property": "typeof window.NDEFRecord",
                 "expectPropertyValue": "function",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             },
 
@@ -831,6 +899,7 @@
                 "property": "navigator.storage.estimate().then(r => r.quota).catch(e => e.message)",
                 "expectPropertyValue": "1337",
                 "exceptPlatforms": [
+                    "web-extension"
                 ]
             }
         ]

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -668,7 +668,7 @@
             },
 
             {
-                "name": "WebUSB API",
+                "name": "WebUSB API requestDevice",
                 "siteURL": "https://example.com/",
                 "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
                 "expectPropertyValue": "No device selected.",
@@ -676,15 +676,38 @@
                 ]
             },
             {
-                "name": "WebUSB API exception",
+                "name": "WebUSB API requestDevice exception",
                 "siteURL": "https://harmful-apis-exception.test",
                 "property": "navigator.usb.requestDevice({filters: []}).catch(e => e.message)",
                 "expectPropertyValue": "mocked-USB-requestDevice-result",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "WebSerial API requestPort",
+                "siteURL": "https://example.com/",
+                "property": "navigator.serial.requestPort().catch(e => e.message)",
+                "expectPropertyValue": "No port selected.",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebSerial API requestPort exception",
+                "siteURL": "https://harmful-apis-exception.test",
+                "property": "navigator.serial.requestPort().catch(e => e.message)",
+                "expectPropertyValue": "mocked-Serial-requestPort-result",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "WebSerial API requestPort domain override",
+                "siteURL": "https://patched-harmful-api-settings.test/",
+                "property": "navigator.serial.requestPort().catch(e => e.message)",
+                "expectPropertyValue": "mocked-Serial-requestPort-result",
+                "exceptPlatforms": [
+                ]
             }
-
-
         ]
     }
 }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -492,6 +492,105 @@
                 "expectPropertyValue": "true",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "NetworkInformation API",
+                "siteURL": "https://example.com/",
+                "property": "typeof navigator.connection",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "NetworkInformation API exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "typeof navigator.connection",
+                "expectPropertyValue": "object",
+                "exceptPlatforms": [
+                ]
+            },
+
+            {
+                "name": "getInstalledRelatedApps API",
+                "siteURL": "https://example.com/",
+                "property": "navigator.getInstalledRelatedApps().then(apps => apps.join(','))",
+                "expectPropertyValue": "overridden-return-value",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "getInstalledRelatedApps API exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.getInstalledRelatedApps().then(apps => apps.join(','))",
+                "expectPropertyValue": "some-returned-app",
+                "exceptPlatforms": [
+                ]
+            },
+
+            {
+                "name": "FileSystemAccess API - showOpenFilePicker",
+                "siteURL": "https://example.com/",
+                "property": "typeof window.showOpenFilePicker",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - showSaveFilePicker",
+                "siteURL": "https://example.com/",
+                "property": "typeof window.showSaveFilePicker",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - showDirectoryPicker",
+                "siteURL": "https://example.com/",
+                "property": "typeof window.showDirectoryPicker",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - showOpenFilePicker exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "typeof window.showOpenFilePicker",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - showSaveFilePicker exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "typeof window.showSaveFilePicker",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - showDirectoryPicker exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "typeof window.showDirectoryPicker",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - DataTransferItem.getAsFileSystemHandle",
+                "siteURL": "https://example.com/",
+                "property": "typeof DataTransferItem.prototype.getAsFileSystemHandle",
+                "expectPropertyValue": "undefined",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "FileSystemAccess API - DataTransferItem.getAsFileSystemHandle exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "typeof DataTransferItem.prototype.getAsFileSystemHandle",
+                "expectPropertyValue": "function",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }

--- a/fingerprinting-protections/tests.json
+++ b/fingerprinting-protections/tests.json
@@ -306,6 +306,104 @@
                 "expectPropertyValue": "devicemotion",
                 "exceptPlatforms": [
                 ]
+            },
+
+            {
+                "name": "AbsoluteOrientationSensor API",
+                "siteURL": "https://example.com/",
+                "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
+                "expectPropertyValue": "threw",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "Accelerometer API",
+                "siteURL": "https://example.com/",
+                "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
+                "expectPropertyValue": "threw",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "GravitySensor API",
+                "siteURL": "https://example.com/",
+                "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
+                "expectPropertyValue": "threw",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "Gyroscope API",
+                "siteURL": "https://example.com/",
+                "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
+                "expectPropertyValue": "threw",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "LinearAccelerationSensor API",
+                "siteURL": "https://example.com/",
+                "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
+                "expectPropertyValue": "threw",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "RelativeOrientationSensor API",
+                "siteURL": "https://example.com/",
+                "property": "new Promise(resolve => { s = new AbsoluteOrientationSensor(); s.addEventListener('error', e => resolve('threw')); s.start(); })",
+                "expectPropertyValue": "threw",
+                "exceptPlatforms": [
+                ]
+            },
+
+            {
+                "name": "accelerometer permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'accelerometer' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "gyroscope permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'gyroscope' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "magnetometer permission",
+                "siteURL": "https://example.com/",
+                "property": "navigator.permissions.query({ name: 'magnetometer' }).then(result => result.state)",
+                "expectPropertyValue": "denied",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "accelerometer permission exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.permissions.query({ name: 'accelerometer' }).then(result => result.state)",
+                "expectPropertyValue": "granted",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "gyroscope permission exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.permissions.query({ name: 'gyroscope' }).then(result => result.state)",
+                "expectPropertyValue": "granted",
+                "exceptPlatforms": [
+                ]
+            },
+            {
+                "name": "magnetometer permission exception",
+                "siteURL": "https://harmful-apis-exception.test/",
+                "property": "navigator.permissions.query({ name: 'magnetometer' }).then(result => result.state)",
+                "expectPropertyValue": "granted",
+                "exceptPlatforms": [
+                ]
             }
         ]
     }


### PR DESCRIPTION
Reference tests for the protection implemented in https://github.com/duckduckgo/content-scope-scripts/pull/527
Note that the protection is not enabled on any platform yet, but I tested these with the extension locally.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204999444634510