### PR TITLE
Add cookie policies to 3p cookie config

### DIFF
--- a/block-third-party-tracking-cookies/config_reference.json
+++ b/block-third-party-tracking-cookies/config_reference.json
@@ -35,7 +35,15 @@
                     }
                 ],
                 "trackerCookie": "enabled",
-                "nonTrackerCookie": "disabled"
+                "nonTrackerCookie": "disabled",
+                "firstPartyTrackerCookiePolicy": {
+                    "threshold": 86400,
+                    "maxAge": 86400
+                },
+                "firstPartyCookiePolicy": {
+                    "threshold": 604800,
+                    "maxAge": 604800
+                }
             },
             "exceptions": [
                 {


### PR DESCRIPTION
Not including these can break the cookie protection implementation in some cases.