### PR TITLE
Remove exception on android for description encoding test

### DIFF
--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -143,7 +143,6 @@
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
                 ],
                 "exceptPlatforms": [
-                    "android-browser",
                     "ios-browser",
                     "safari-extension"
                 ]


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1204980841887189/f

Now that we have descriptions for broken site reports on Android, we should be checking the encoding works for them.