### PR TITLE
Add deep extraction key to test config for AMP

### DIFF
--- a/amp-protections/config_reference.json
+++ b/amp-protections/config_reference.json
@@ -28,7 +28,8 @@
                     "_amp",
                     "amp_",
                     "?amp"
-                ]
+                ],
+                "deepExtractionEnabled": true
             }
         }
     },


### PR DESCRIPTION
This key is needed to fix tests in https://github.com/duckduckgo/BrowserServicesKit/pull/611