### PR TITLE
Validate 'isFirstParty' logic for tracker that only has eTLD+2 domain defined

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -33,7 +33,7 @@
                 "requestURL": "https://ignore.test/",
                 "requestType": "script",
                 "expectAction": "ignore"
-            },            
+            },
             {
                 "name": "same party ignore with deeper subdomain",
                 "siteURL": "https://bad.etld-plus-two.site/",
@@ -1084,7 +1084,7 @@
                 "expectAction": "redirect",
                 "expectRedirect": "data:application/javascript;base64,KGZ1bmN0aW9uKCkge3dpbmRvdy5zdXJyb2dhdGUxPXRydWV9KSgpOw==",
                 "expectExpression": "window.surrogate1 === true"
-            }            
+            }
         ]
     }
 }

--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -33,6 +33,13 @@
                 "requestURL": "https://ignore.test/",
                 "requestType": "script",
                 "expectAction": "ignore"
+            },            
+            {
+                "name": "same party ignore with deeper subdomain",
+                "siteURL": "https://bad.etld-plus-two.site/",
+                "requestURL": "https://bad.etld-plus-two.site/script.js",
+                "requestType": "script",
+                "expectAction": "ignore"
             },
             {
                 "name": "tracker loads ignore",
@@ -1077,7 +1084,7 @@
                 "expectAction": "redirect",
                 "expectRedirect": "data:application/javascript;base64,KGZ1bmN0aW9uKCkge3dpbmRvdy5zdXJyb2dhdGUxPXRydWV9KSgpOw==",
                 "expectExpression": "window.surrogate1 === true"
-            }
+            }            
         ]
     }
 }

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -255,6 +255,21 @@
             "rules": [],
             "default": "ignore"
         },
+        "bad.etld-plus-two.site": {
+            "domain": "bad.etld-plus-two.site",
+            "owner": {
+                "name": "Test Site for Tracker Blocking With eTLD+2",
+                "displayName": "Bad Third Party Site eTLD+2",
+                "privacyPolicy": "",
+                "url": "http://bad.etld-plus-two.site"
+            },
+            "prevalence": 0.1,
+            "fingerprinting": 3,
+            "cookies": 0.1,
+            "categories": [],
+            "default": "block",
+            "rules": []
+        },
         "tracker.test": {
             "domain": "tracker.test",
             "owner": {
@@ -819,6 +834,13 @@
             "prevalence": 0.1,
             "displayName": "Test Site for Tracker Blocking"
         },
+        "Test Site for Tracker Blocking With eTLD+2": {
+            "domains": [
+                "bad.etld-plus-two.site"
+            ],
+            "prevalence": 0.1,
+            "displayName": "Bad Third Party Site eTLD+2"
+        },
         "Tests for formatting": {
             "domains": [
                 "format.test"
@@ -876,6 +898,7 @@
         "bad.third-party.site": "Test Site for Tracker Blocking",
         "sometimes-bad.third-party.site": "Test Site for Tracker Blocking",
         "broken.third-party.site": "Test Site for Tracker Blocking",
+        "bad.etld-plus-two.site": "Test Site for Tracker Blocking With eTLD+2",
         "format.test": "Tests for formatting",
         "third-party.site": "Test Site for Tracker Blocking",
         "tracker.test": "Test Site for Tracker Blocking",


### PR DESCRIPTION
- Added a test that validates that, when Tracker is defined for a eTLD+2 domain (e.g. bad.etld-plus-two.site), tracker requests are correctly Ignored
- This validates a fix on windows, we recently discovered that `bad.third-party.site` had some sub-requests blocked due to 1st-vs-3rd party logic looking up eTLD+1 for tracker entity lookup (which is `third-party.site` - so in this case, did not find the `bad.third-party.site` Entity). This has now been fixed and is instead using the Tracker's Entity name to look up the Entity.

See https://app.asana.com/0/1199608453935138/1208394000709735/f for more detail.