### PR TITLE
[DO NOT MERGE] Revert "Validate 'isFirstParty' logic for tracker that only has eTLD+2 domain defined"

### DIFF
--- a/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
+++ b/tracker-radar-tests/TR-domain-matching/domain_matching_tests.json
@@ -35,13 +35,6 @@
                 "expectAction": "ignore"
             },
             {
-                "name": "same party ignore with deeper subdomain",
-                "siteURL": "https://bad.etld-plus-two.site/",
-                "requestURL": "https://bad.etld-plus-two.site/script.js",
-                "requestType": "script",
-                "expectAction": "ignore"
-            },
-            {
                 "name": "tracker loads ignore",
                 "siteURL": "https://bad.third-party.site/",
                 "requestURL": "https://ignore.test/",

--- a/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
+++ b/tracker-radar-tests/TR-domain-matching/tracker_radar_reference.json
@@ -255,21 +255,6 @@
             "rules": [],
             "default": "ignore"
         },
-        "bad.etld-plus-two.site": {
-            "domain": "bad.etld-plus-two.site",
-            "owner": {
-                "name": "Test Site for Tracker Blocking With eTLD+2",
-                "displayName": "Bad Third Party Site eTLD+2",
-                "privacyPolicy": "",
-                "url": "http://bad.etld-plus-two.site"
-            },
-            "prevalence": 0.1,
-            "fingerprinting": 3,
-            "cookies": 0.1,
-            "categories": [],
-            "default": "block",
-            "rules": []
-        },
         "tracker.test": {
             "domain": "tracker.test",
             "owner": {
@@ -834,13 +819,6 @@
             "prevalence": 0.1,
             "displayName": "Test Site for Tracker Blocking"
         },
-        "Test Site for Tracker Blocking With eTLD+2": {
-            "domains": [
-                "bad.etld-plus-two.site"
-            ],
-            "prevalence": 0.1,
-            "displayName": "Bad Third Party Site eTLD+2"
-        },
         "Tests for formatting": {
             "domains": [
                 "format.test"
@@ -898,7 +876,6 @@
         "bad.third-party.site": "Test Site for Tracker Blocking",
         "sometimes-bad.third-party.site": "Test Site for Tracker Blocking",
         "broken.third-party.site": "Test Site for Tracker Blocking",
-        "bad.etld-plus-two.site": "Test Site for Tracker Blocking With eTLD+2",
         "format.test": "Tests for formatting",
         "third-party.site": "Test Site for Tracker Blocking",
         "tracker.test": "Test Site for Tracker Blocking",


### PR DESCRIPTION
Reverts duckduckgo/privacy-reference-tests#132 - testing to see if it fixes the CI.