### PR TITLE
This breaks the tests on macOS, so reverting it for now.

### DIFF
--- a/suggestions/suggestions-regular-window-tabs.json
+++ b/suggestions/suggestions-regular-window-tabs.json
@@ -16,7 +16,7 @@
         "tabs": [
           { "tabId": "ebbd25e2-7b32-4cc4-8e7e-ea16e829bbc8", "title": "Example", "uri": "https://example.com" },
           { "tabId": "fbd713a1-a7a5-4843-8b50-3775f2ce1299", "title": "Selected Tab", "uri": "https://another-example.com" },
-          { "tabId": "f4386ef1-675d-43f0-b0d3-868488ab9c56", "title": "New Tab", "uri": "duck://ntp" },
+          { "tabId": "f4386ef1-675d-43f0-b0d3-868488ab9c56", "title": "New Tab", "uri": "duck://newtab" },
           { "tabId": "8f64b4b9-2aac-4d34-bbf6-4641de875d14", "title": "Bookmarks", "uri": "duck://bookmarks" },
           { "tabId": "6c4c6dfd-f8a7-421d-9b8c-a5d3ec94bea4", "title": "Settings", "uri": "duck://settings" }
         ]


### PR DESCRIPTION
The macOS browser uses `newtab` instead of `ntp` internally, so we need to keep that for consistency across platforms.