### PR TITLE
Add reference tests for breakageData parameter

### DIFF
--- a/broken-site-reporting/README.md
+++ b/broken-site-reporting/README.md
@@ -31,6 +31,7 @@ Test suite specific fields:
 - `jsPerformance` - string - optional field containing the js performance value measured on the page
 - `locale` - string - optional field containing the locale of the application (e.g. 'en')
 - `userRefreshCount` - string - optional field containing the number of times the user refreshed the current page
+- `breakageData` - string - optional field containing pre-encoded breakage data from content scripts (already encoded, platforms MUST NOT re-encode and MUST pass this value AS-IS to the report URL)
 - `expectReportURLPrefix` - string - resulting report URL should be prefixed with this string
 - `expectReportURLParams` - Array of `{name: '', value: ''}` objects - resulting report URL should have the following set of URL parameters with matching values
     - `value` is an optional check for an exact value match.
@@ -64,7 +65,8 @@ for $testSet in test.json
         manufacturer=$test.manufacturer,
         model=$test.model,
         os=$test.os,
-        gpcEnabled=$test.gpcEnabled
+        gpcEnabled=$test.gpcEnabled,
+        breakageData=$test.breakageData
     )
 
     if $test.expectReportURLPrefix
@@ -105,7 +107,8 @@ for $testSet in test.json
             manufacturer=$report.manufacturer,
             model=$report.model,
             os=$report.os,
-            gpcEnabled=$report.gpcEnabled
+            gpcEnabled=$report.gpcEnabled,
+            breakageData=$report.breakageData
         )
 
         if $report.expectReportURLPrefix

--- a/broken-site-reporting/tests.json
+++ b/broken-site-reporting/tests.json
@@ -495,6 +495,54 @@
                     "safari-extension",
                     "windows-browser"
                 ]
+            },
+            {
+                "name": "Test breakageData is passed as-is without double-encoding (simple)",
+                "siteURL": "https://example.test/",
+                "wasUpgraded": false,
+                "category": "content",
+                "blockedTrackers": [],
+                "surrogates": [],
+                "atb": "v123-456g",
+                "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
+                "breakageData": "%7B%22test%22%3A%22value%22%7D",
+                "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                "expectReportURLParams": [
+                    {"name": "category", "value": "content"},
+                    {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                    {"name": "upgradedHttps", "value": "false"},
+                    {"name": "tds", "value": "abc123"},
+                    {"name": "blockedTrackers", "value": ""},
+                    {"name": "surrogates", "value": ""},
+                    {"name": "protectionsState", "value": "true"},
+                    {"name": "breakageData", "value": "%7B%22test%22%3A%22value%22%7D"}
+                ],
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Test breakageData is passed as-is without double-encoding (complex with special chars and URL-like value)",
+                "siteURL": "https://example.test/",
+                "wasUpgraded": false,
+                "category": "content",
+                "blockedTrackers": [],
+                "surrogates": [],
+                "atb": "v123-456g",
+                "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
+                "breakageData": "%7B%22data%22%3A%7B%22nested%22%3A%7B%22value1-hyphens%22%3Atrue%2C%22value2Array%7B%7D%22%3A%5B%22.a-value%22%5D%7D%7D%2C%20%22urlLike%22%3A%20%22https%3A%2F%2Fexample.com%2Fpath%3Fquery%3Dvalue%26other%3D123%22%7D",
+                "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                "expectReportURLParams": [
+                    {"name": "category", "value": "content"},
+                    {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                    {"name": "upgradedHttps", "value": "false"},
+                    {"name": "tds", "value": "abc123"},
+                    {"name": "blockedTrackers", "value": ""},
+                    {"name": "surrogates", "value": ""},
+                    {"name": "protectionsState", "value": "true"},
+                    {"name": "breakageData", "value": "%7B%22data%22%3A%7B%22nested%22%3A%7B%22value1-hyphens%22%3Atrue%2C%22value2Array%7B%7D%22%3A%5B%22.a-value%22%5D%7D%7D%2C%20%22urlLike%22%3A%20%22https%3A%2F%2Fexample.com%2Fpath%3Fquery%3Dvalue%26other%3D123%22%7D"}
+                ],
+                "exceptPlatforms": []
             }
         ]
     }


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1212311623899110/task/1213015238129928?focus=true

Adds reference tests for the `breakageData` parameter to ensure the value doesn't get double-encoded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates reference tests/docs to include a new optional URL parameter check; no production logic changes.
> 
> **Overview**
> Adds support in the broken-site reporting reference suite for an optional `breakageData` parameter, explicitly documenting that it is **already pre-encoded** and must be forwarded *as-is*.
> 
> Updates the README pseudo-code examples to pass `breakageData` through to `getReportURL`, and adds two new `tests.json` cases (simple + complex/special-character payload) that assert the `breakageData` query parameter matches the provided encoded value exactly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f8e5c7f992227293fe899cddc2b09c25b2e1421. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->