### PR TITLE
Remove windows-browser from exceptPlatforms in storage-clearing tests

### DIFF
--- a/storage-clearing/tests.json
+++ b/storage-clearing/tests.json
@@ -51,8 +51,7 @@
                 "expectCookieRemoved": false,
                 "exceptPlatforms": [
                     "ios-browser",
-                    "android-browser",
-                    "windows-browser"
+                    "android-browser"
                 ]
             },
             {
@@ -76,8 +75,7 @@
                 "expectCookieRemoved": false,
                 "exceptPlatforms": [
                     "ios-browser",
-                    "android-browser",
-                    "windows-browser"
+                    "android-browser"
                 ]
             },
             {
@@ -87,8 +85,7 @@
                 "expectCookieRemoved": false,
                 "exceptPlatforms": [
                     "ios-browser",
-                    "android-browser",
-                    "windows-browser"
+                    "android-browser"
                 ]
             },
             {
@@ -98,8 +95,7 @@
                 "expectCookieRemoved": false,
                 "exceptPlatforms": [
                     "ios-browser",
-                    "android-browser",
-                    "windows-browser"
+                    "android-browser"
                 ]
             },
             {


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/72649045549333/task/1211398846337324?focus=true

## Summary

- Remove `windows-browser` from the `exceptPlatforms` arrays in 4 storage-clearing test cases that should work after the changes in https://app.asana.com/1/137249556945/project/1210132634900450/task/1205150004869238?focus=true
- These tests are not running in Windows yet, implementation here: https://github.com/duckduckgo/windows-browser/pull/6766 is merged to `develop`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-data-only change that adjusts platform exclusions; risk is limited to potentially exposing previously masked Windows test failures.
> 
> **Overview**
> Updates `storage-clearing/tests.json` to **stop excluding `windows-browser`** from four fireproofing-related cookie-clearing test cases (subdomain/dot-notation scenarios), so Windows is expected to follow the same behavior as other supported platforms.
> 
> No production logic changes; this only adjusts cross-platform test expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ff24f95f49d8b6f9b583b749b0447b258942949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->