### PR TITLE
Add EventHub cross-platform reference tests

### DIFF
--- a/event-hub/README.md
+++ b/event-hub/README.md
@@ -1,0 +1,78 @@
+# EventHub Tests
+
+Privacy Feature: <https://app.asana.com/1/137249556945/task/1212993781157339>
+
+EventHub is a reusable, config-driven telemetry framework for web-side signals. A content-scope-scripts
+detector emits a named `webEvent { type, data }`; the native client processes it per the remote
+`eventHub` configuration and fires a telemetry pixel — either aggregated (a bucketed counter over a
+period) or immediate (one pixel per event).
+
+## Goals
+
+These tests verify the **pure, deterministic** parts of EventHub that must behave identically on every
+platform, independent of timers, scheduling, persistence or app lifecycle:
+
+- **Bucket assignment** — mapping a counter value onto a configured, ordered set of named buckets.
+- **Stop-counting** — deciding when a counter has reached the open-ended bucket and need not keep counting.
+- **Attribution period** — rounding a period-start timestamp down to the start of its interval.
+- **Data parameter encoding** — turning a forwarded `webEvent.data` value into a pixel parameter.
+
+The stateful runtime (per-tab de-duplication, period windowing, timer scheduling, foreground gating,
+write-behind persistence and restart behaviour) is **out of scope** here because it is inherently
+time- and platform-mechanism-specific; each platform covers it with native tests.
+
+## Structure
+
+`tests.json` contains four independent sets.
+
+### `bucketAssignment`
+
+- `count` — int — the current counter value.
+- `buckets` — object — ordered map of bucket name → `{ "gte": int, "lt": int? }`. A bucket matches when
+  `count >= gte` and (`lt` is absent OR `count < lt`). Iteration follows the JSON insertion order.
+- `expectBucket` — string | null — the name of the first matching bucket, or `null` if none match.
+
+### `stopCounting`
+
+- `count` — int — the current counter value.
+- `buckets` — object — as above.
+- `expectShouldStopCounting` — bool — `true` when no bucket has a `gte` greater than `count` (the value
+  is in the highest, open-ended bucket and further counting cannot change the outcome). An empty bucket
+  set yields `true`.
+
+### `attributionPeriod`
+
+- `periodStartMillis` — int — the period start as a UTC epoch timestamp in milliseconds.
+- `periodSeconds` — int — the period length in seconds.
+- `expectAttributionPeriod` — int — the interval start as UTC epoch **seconds**:
+  `floor((periodStartMillis / 1000) / periodSeconds) * periodSeconds`.
+
+### `dataParameterEncoding`
+
+- `dataValue` — any JSON value — the value taken from `webEvent.data[dataKey]`.
+- `expectEncodedParameter` — string — `dataValue` serialized to compact JSON (no insignificant
+  whitespace) and then percent-encoded. Test values are chosen so the result is identical across
+  standard component encoders (e.g. `encodeURIComponent` / `Uri.EscapeDataString`).
+
+## Pseudo-code implementation
+
+```python
+for $set in tests.json
+  for $test in $set.tests
+    if $test.exceptPlatforms includes 'current-platform'
+        skip
+
+    switch $set:
+      bucketAssignment:
+        expect(bucketCount($test.count, $test.buckets) === $test.expectBucket)
+      stopCounting:
+        expect(shouldStopCounting($test.count, $test.buckets) === $test.expectShouldStopCounting)
+      attributionPeriod:
+        expect(attributionPeriod($test.periodStartMillis, $test.periodSeconds) === $test.expectAttributionPeriod)
+      dataParameterEncoding:
+        expect(encodeDataParameter($test.dataValue) === $test.expectEncodedParameter)
+```
+
+## Platform exceptions
+
+None — every supported behaviour is identical across platforms, so all `exceptPlatforms` lists are empty.

--- a/event-hub/tests.json
+++ b/event-hub/tests.json
@@ -1,0 +1,262 @@
+{
+    "bucketAssignment": {
+        "name": "EventHub counter bucket assignment",
+        "desc": "Maps a counter value onto a configured, insertion-ordered set of named buckets. A bucket matches when count >= gte and (lt is absent OR count < lt); the upper bound is exclusive. The first matching bucket (in insertion order) wins. If no bucket matches, the result is null.",
+        "tests": [
+            {
+                "name": "Count 0 matches the first bucket",
+                "count": 0,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "3-5": { "gte": 3, "lt": 6 },
+                    "6-10": { "gte": 6, "lt": 11 },
+                    "11-20": { "gte": 11, "lt": 21 },
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectBucket": "0",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Count within a range matches that range",
+                "count": 2,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "3-5": { "gte": 3, "lt": 6 },
+                    "6-10": { "gte": 6, "lt": 11 },
+                    "11-20": { "gte": 11, "lt": 21 },
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectBucket": "1-2",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Upper bound is exclusive (count equal to lt falls in the lower bucket)",
+                "count": 10,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "3-5": { "gte": 3, "lt": 6 },
+                    "6-10": { "gte": 6, "lt": 11 },
+                    "11-20": { "gte": 11, "lt": 21 },
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectBucket": "6-10",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Lower bound is inclusive (count equal to gte falls in the upper bucket)",
+                "count": 11,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "3-5": { "gte": 3, "lt": 6 },
+                    "6-10": { "gte": 6, "lt": 11 },
+                    "11-20": { "gte": 11, "lt": 21 },
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectBucket": "11-20",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Count at the open-ended bucket lower bound matches it",
+                "count": 40,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "3-5": { "gte": 3, "lt": 6 },
+                    "6-10": { "gte": 6, "lt": 11 },
+                    "11-20": { "gte": 11, "lt": 21 },
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectBucket": "40+",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Large count matches the open-ended bucket",
+                "count": 100,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "3-5": { "gte": 3, "lt": 6 },
+                    "6-10": { "gte": 6, "lt": 11 },
+                    "11-20": { "gte": 11, "lt": 21 },
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectBucket": "40+",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "No matching bucket yields null",
+                "count": 3,
+                "buckets": {
+                    "5-9": { "gte": 5, "lt": 10 }
+                },
+                "expectBucket": null,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Empty bucket set yields null",
+                "count": 5,
+                "buckets": {},
+                "expectBucket": null,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "First matching bucket wins for overlapping ranges (insertion order)",
+                "count": 7,
+                "buckets": {
+                    "broad": { "gte": 0, "lt": 100 },
+                    "narrow": { "gte": 5, "lt": 10 }
+                },
+                "expectBucket": "broad",
+                "exceptPlatforms": []
+            }
+        ]
+    },
+    "stopCounting": {
+        "name": "EventHub counter stop-counting",
+        "desc": "Decides when further counting can no longer change which bucket a value falls into, i.e. the value is in the highest (open-ended) bucket. True when no bucket has a lower bound (gte) greater than the current count. An empty bucket set also stops counting.",
+        "tests": [
+            {
+                "name": "Below the highest bucket keeps counting",
+                "count": 0,
+                "buckets": {
+                    "0": { "gte": 0, "lt": 1 },
+                    "1-2": { "gte": 1, "lt": 3 },
+                    "40+": { "gte": 40 }
+                },
+                "expectShouldStopCounting": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Just below the highest bucket keeps counting",
+                "count": 39,
+                "buckets": {
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectShouldStopCounting": false,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "At the open-ended bucket lower bound stops counting",
+                "count": 40,
+                "buckets": {
+                    "21-39": { "gte": 21, "lt": 40 },
+                    "40+": { "gte": 40 }
+                },
+                "expectShouldStopCounting": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Above the open-ended bucket lower bound stops counting",
+                "count": 100,
+                "buckets": {
+                    "40+": { "gte": 40 }
+                },
+                "expectShouldStopCounting": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Empty bucket set stops counting",
+                "count": 5,
+                "buckets": {},
+                "expectShouldStopCounting": true,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "A higher bucket still reachable keeps counting",
+                "count": 3,
+                "buckets": {
+                    "5-9": { "gte": 5, "lt": 10 }
+                },
+                "expectShouldStopCounting": false,
+                "exceptPlatforms": []
+            }
+        ]
+    },
+    "attributionPeriod": {
+        "name": "EventHub attribution period calculation",
+        "desc": "Rounds a period-start timestamp (UTC epoch milliseconds) down to the start of the interval of length periodSeconds, expressed as UTC epoch seconds: floor((periodStartMillis / 1000) / periodSeconds) * periodSeconds. This is sent as the pixel's attributionPeriod parameter.",
+        "tests": [
+            {
+                "name": "Daily period rounds down to the start of the UTC day",
+                "periodStartMillis": 1767312060000,
+                "periodSeconds": 86400,
+                "expectAttributionPeriod": 1767312000,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Hourly period rounds down to the start of the UTC hour",
+                "periodStartMillis": 1767374100000,
+                "periodSeconds": 3600,
+                "expectAttributionPeriod": 1767373200,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Sub-minute remainder rounds down to the start of the minute",
+                "periodStartMillis": 1767312030000,
+                "periodSeconds": 60,
+                "expectAttributionPeriod": 1767312000,
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Timestamp already on an interval boundary is unchanged",
+                "periodStartMillis": 1767312000000,
+                "periodSeconds": 86400,
+                "expectAttributionPeriod": 1767312000,
+                "exceptPlatforms": []
+            }
+        ]
+    },
+    "dataParameterEncoding": {
+        "name": "EventHub data parameter encoding",
+        "desc": "Encodes a value forwarded from webEvent.data into a pixel parameter: serialize the value to compact JSON (no insignificant whitespace), then percent-encode that JSON string. The test values are chosen so the result is identical across standard component encoders (e.g. encodeURIComponent / Uri.EscapeDataString).",
+        "tests": [
+            {
+                "name": "Null is encoded as the literal null",
+                "dataValue": null,
+                "expectEncodedParameter": "null",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "A string is JSON-quoted then percent-encoded",
+                "dataValue": "logged-in",
+                "expectEncodedParameter": "%22logged-in%22",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "An object is compact-serialized then percent-encoded",
+                "dataValue": { "data": true },
+                "expectEncodedParameter": "%7B%22data%22%3Atrue%7D",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "A boolean is encoded as its JSON literal",
+                "dataValue": true,
+                "expectEncodedParameter": "true",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "A number is encoded as its JSON literal",
+                "dataValue": 42,
+                "expectEncodedParameter": "42",
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Whitespace inside a string value is percent-encoded",
+                "dataValue": "a b",
+                "expectEncodedParameter": "%22a%20b%22",
+                "exceptPlatforms": []
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Asana task: https://app.asana.com/1/137249556945/project/481882893211075/task/1212993781157339?focus=true

---

Adds a new `event-hub/` reference-test suite for **EventHub**, the config-driven web-telemetry framework. EventHub takes a named `webEvent { type, data }` emitted by a content-scope-scripts detector and, per the remote `eventHub` config, fires either an aggregated (bucketed counter over a period) or immediate telemetry pixel.

This suite covers only the **pure, deterministic** primitives that must behave identically on every platform, independent of timers, scheduling, persistence or app lifecycle:

- **`bucketAssignment`** (9 cases) — map a counter value onto an ordered set of named buckets (`gte` / optional `lt`), in JSON insertion order.
- **`stopCounting`** (6 cases) — decide when a counter has reached the open-ended bucket and need not keep counting.
- **`attributionPeriod`** (4 cases) — round a period-start timestamp down to its interval start: `floor((periodStartMillis / 1000) / periodSeconds) * periodSeconds`.
- **`dataParameterEncoding`** (6 cases) — serialize a forwarded `webEvent.data` value to compact JSON, then percent-encode it.

The stateful runtime (per-tab de-duplication, period windowing, timer scheduling, foreground gating, write-behind persistence, restart behaviour) is intentionally **out of scope** — it is time- and platform-mechanism-specific and is covered by each platform's native test suite. This split is documented in `event-hub/README.md`.

All `exceptPlatforms` lists are empty: every behaviour here is identical across platforms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and JSON reference tests only; no application or telemetry runtime code changes.
> 
> **Overview**
> Introduces a new **`event-hub/`** cross-platform reference-test package for EventHub’s **pure, deterministic** telemetry helpers (runtime behavior like timers and persistence stays out of scope and is documented in the README).
> 
> **`tests.json`** adds four test sets with empty `exceptPlatforms`: **bucket assignment** (ordered `gte`/`lt` buckets, insertion-order wins), **stop counting** (open-ended / highest bucket), **attribution period** (floor interval start in UTC seconds), and **data parameter encoding** (compact JSON + percent-encoding). The README describes each set’s fields and the pseudo-code runners should use to execute them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7de5ed6c4590a333b82174fd6e2f54ab24dc83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->